### PR TITLE
New ignoreRequiredCheck flag making all properties optional, and new ability to serialize object using mappings from a specified class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json2typescript",
-  "version": "1.1.0",
+  "version": "1.3.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json2typescript",
-  "version": "1.2.3",
+  "version": "1.3.0-rc.1",
   "description": "Provides TypeScript methods to map a JSON object to a JavaScript object on runtime",
   "keywords": [
     "convert",

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -211,9 +211,15 @@ export class JsonConvert {
 
 
     /**
-     * Tries to serialize a TypeScript object or array of objects to JSON.
+     * Tries to serialize a TypeScript object or array of objects to JSON using the mappings defined on
+     * the specified class reference.  Note that if a class reference is provided, it will be used as
+     * the source of property mapping for serialization, even if the object or one of its elements is
+     * an instance of a different class with its own mappings.  Also, ONLY the properties from the
+     * class reference will be serialized - any additional properties on the object(s) will be silently
+     * ignored.
      *
      * @param data object or array of objects
+     * @param classReference the class reference which provides the property mappings to use
      *
      * @returns the JSON object
      *
@@ -222,7 +228,7 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serialize<T>(data: T | T[]): any | any[] {
+    serialize<T>(data: any | any[], classReference?: { new(): T }): any | any[] {
 
         if (this.operationMode === OperationMode.DISABLE) {
             return data;
@@ -230,23 +236,29 @@ export class JsonConvert {
 
         // Call the appropriate method depending on the type
         if (data instanceof Array) {
-            return this.serializeArray(data);
+            return this.serializeArray(data, classReference);
         } else if (typeof data === "object") { // careful: an array is an object in TypeScript!
-            return this.serializeObject(data);
+            return this.serializeObject(data, classReference);
         } else {
             throw new Error(
-                "Fatal error in JsonConvert. " +
-                "Passed parameter data in JsonConvert.serialize() is not in valid format (object or array)." +
-                "\n"
+              "Fatal error in JsonConvert. " +
+              "Passed parameter data in JsonConvert.serialize() is not in valid format (object or array)." +
+              "\n"
             );
         }
-
     }
 
     /**
-     * Tries to serialize a TypeScript object to a JSON object.
+     * Tries to serialize a TypeScript object to a JSON object using either the mappings on the
+     * provided class reference, if present, or on the provided object.  Note that if a class
+     * reference is provided, it will be used as the source of property mapping for serialization,
+     * even if the object is itself an instance of a different class with its own mappings.
+     * Also, ONLY the properties from the class reference will be serialized - any additional
+     * properties on the object will be silently ignored.
      *
-     * @param instance TypeScript instance
+     * @param data object containing the values to be mapped to a JSON object, must be an
+     *             instance of a class with JSON mappings if no class reference is provided
+     * @param classReference optional class reference which provides the property mappings to use
      *
      * @returns the JSON object
      *
@@ -255,14 +267,14 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serializeObject<T>(instance: T): any {
+    serializeObject<T>(data: any, classReference?: { new(): T }): any {
 
         if (this.operationMode === OperationMode.DISABLE) {
-            return instance;
+            return data;
         }
 
         // Check if the passed type is allowed
-        if (instance === undefined) {
+        if (data === undefined) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -270,7 +282,7 @@ export class JsonConvert {
                 "\n"
             );
 
-        } else if (instance === null) {
+        } else if (data === null) {
 
             if (this.valueCheckingMode === ValueCheckingMode.DISALLOW_NULL) {
                 throw new Error(
@@ -279,10 +291,10 @@ export class JsonConvert {
                     "\n"
                 );
             } else {
-                return instance;
+                return data;
             }
 
-        } else if (typeof (instance) !== "object" || instance instanceof Array) {
+        } else if (typeof (data) !== "object" || data instanceof Array) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -296,14 +308,20 @@ export class JsonConvert {
         if (this.operationMode === OperationMode.LOGGING) {
             console.log("----------");
             console.log("Receiving JavaScript instance:");
-            console.log(instance);
+            console.log(data);
         }
 
         let jsonObject: any = {};
+        let instance: T;
+        if (!!classReference) {
+            instance = new classReference();
+        } else {
+            instance = <T>data;
+        }
 
-        // Loop through all initialized class properties
+        // Loop through all initialized class properties on the mapping instance
         for (const propertyKey of Object.keys(instance)) {
-            this.serializeObject_loopProperty(instance, propertyKey, jsonObject);
+            this.serializeObject_loopProperty(data, instance, propertyKey, jsonObject);
         }
 
         if (this.operationMode === OperationMode.LOGGING) {
@@ -317,9 +335,16 @@ export class JsonConvert {
     }
 
     /**
-     * Tries to serialize a TypeScript array to a JSON array.
+     * Tries to serialize a TypeScript array to a JSON array using either the mappings on the
+     * provided class reference, if present, or on the provided object.  Note that if a class
+     * reference is provided, ALL objects in the array will be serialized using the mappings
+     * from that class reference, even if they're actually instances of a different class.
+     * Also, ONLY the properties from the class reference will be serialized - any additional
+     * properties on the objects will be silently ignored.
      *
-     * @param instanceArray array of TypeScript instances
+     * @param dataArray array of objects containing the values to be mapped to a JSON object, which
+     *                  must be instances of classes with JSON mappings if no class reference is provided
+     * @param classReference optional class reference which provides the property mappings to use
      *
      * @returns the JSON array
      *
@@ -328,14 +353,14 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serializeArray<T>(instanceArray: T[]): any[] {
+    serializeArray<T>(dataArray: any[], classReference?: { new(): T }): any[] {
 
         if (this.operationMode === OperationMode.DISABLE) {
-            return instanceArray;
+            return dataArray;
         }
 
         // Check if the passed type is allowed
-        if (instanceArray === undefined) {
+        if (dataArray === undefined) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -343,7 +368,7 @@ export class JsonConvert {
                 "\n"
             );
 
-        } else if (instanceArray === null) {
+        } else if (dataArray === null) {
 
             if (this.valueCheckingMode === ValueCheckingMode.DISALLOW_NULL) {
                 throw new Error(
@@ -352,10 +377,10 @@ export class JsonConvert {
                     "\n"
                 );
             } else {
-                return instanceArray;
+                return dataArray;
             }
 
-        } else if (typeof (instanceArray) !== "object" || instanceArray instanceof Array === false) {
+        } else if (typeof (dataArray) !== "object" || dataArray instanceof Array === false) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -369,14 +394,14 @@ export class JsonConvert {
         if (this.operationMode === OperationMode.LOGGING) {
             console.log("----------");
             console.log("Receiving JavaScript array:");
-            console.log(instanceArray);
+            console.log(dataArray);
         }
 
         let jsonArray: any[] = [];
 
         // Loop through all array elements
-        for (const classInstance of <any> instanceArray) {
-            jsonArray.push(this.serializeObject(classInstance));
+        for (const dataObject of <any> dataArray) {
+            jsonArray.push(this.serializeObject(dataObject, classReference));
         }
 
         if (this.operationMode === OperationMode.LOGGING) {
@@ -582,15 +607,16 @@ export class JsonConvert {
 
 
     /**
-     * Tries to find the JSON mapping for a given class property and finally assign the value.
+     * Tries to find the JSON mapping for a given class property from the given instance used for mapping,
+     * and finally assign the value from the given dataObject
      *
-     * @param instance the instance of the class
+     * @param dataObject the object containing the value to be assigned
+     * @param instance the instance of the class used for mapping
      * @param classPropertyName the property name
      * @param json the JSON object
-     *
      * @throws throws an Error in case of failure
      */
-    private serializeObject_loopProperty(instance: any, classPropertyName: string, json: any): void {
+    private serializeObject_loopProperty(dataObject: any, instance: any, classPropertyName: string, json: any): void {
 
         // Check if a JSON-object mapping is possible for a property
         const mappingOptions: MappingOptions | null = this.getClassPropertyMappingOptions(instance, classPropertyName);
@@ -605,7 +631,7 @@ export class JsonConvert {
         let isOptional: boolean = mappingOptions.isOptional;
         let customConverter: any = mappingOptions.customConverter;
 
-        let classInstancePropertyValue: any = instance[classPropertyName];
+        let classInstancePropertyValue: any = dataObject[classPropertyName];
 
 
         // Check if the class property value exists
@@ -776,7 +802,7 @@ export class JsonConvert {
                     else throw new Error("\tReason: Given value is null.");
                 }
 
-                if (serialize) return this.serializeObject(value);
+                if (serialize) return this.serializeObject(value, expectedJsonType);
                 else return this.deserializeObject(value, expectedJsonType);
 
             } else if (expectedJsonType === Any || expectedJsonType === null || expectedJsonType === Object) { // general object

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -751,16 +751,18 @@ export class JsonConvert {
         // Check if mapping is defined
         if (typeof (mappings) === "undefined") return null;
 
-        // Get direct mapping if possible
-        const directMappingName: string = instance[Settings.CLASS_IDENTIFIER] + "." + propertyName;
-        if (typeof (mappings[directMappingName]) !== "undefined") {
-            return mappings[directMappingName];
-        }
-
-        // No mapping was found, try to find some
-        const indirectMappingNames: string[] = Object.keys(mappings).filter(key => key.match("\\." + propertyName + "$")); // use endsWidth in later versions
-        if (indirectMappingNames.length > 0) {
-            return mappings[indirectMappingNames[0]];
+        /* Find mapping by iterating up the prototype chain to find a matching mapping, rather than
+         * just searching by property name. */
+        let prototype = Object.getPrototypeOf(instance);
+        while (prototype != null) {
+            const classIdentifier = prototype[Settings.CLASS_IDENTIFIER];
+            if (!!classIdentifier) {
+                const mappingName: string = classIdentifier + "." + propertyName;
+                if (typeof (mappings[mappingName]) !== "undefined") {
+                    return mappings[mappingName];
+                }
+            }
+            prototype = Object.getPrototypeOf(prototype);
         }
 
         return null;

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -159,8 +159,10 @@ export class JsonConvert {
     /**
      * Determines whether the check for "required" properties should be ignored, making ALL
      * mapped values optional, whether or not the isOptional property mapping parameter is set.
-     * If true, any missing properties when serializing or deserializing will be ignored, as if they
-     * were marked optional.  Defaults to false.
+     * If true, any missing properties (undefined) when serializing or deserializing will be
+     * ignored, as if they were marked optional.  Note that properties explicitly set to null
+     * will be unaffected by this flag - they will be ignored if optional and included if not.
+     * Defaults to false.
      * @returns {boolean} true if all mapped properties will be considered optional, even if the mapping
      *                    doesn't explicitly specify this, false if the mapping will determine whether
      *                    a property is optional or not (default)
@@ -172,8 +174,10 @@ export class JsonConvert {
     /**
      * Determines whether the check for "required" properties should be ignored, making ALL
      * mapped values optional, whether or not the isOptional property mapping parameter is set.
-     * If true, any missing properties when serializing or deserializing will be ignored, as if they
-     * were marked optional.  Defaults to false.
+     * If true, any missing properties (undefined) when serializing or deserializing will be
+     * ignored, as if they were marked optional.  Note that properties explicitly set to null
+     * will be unaffected by this flag - they will be ignored if optional and included if not.
+     * Defaults to false.
      * @param value true if all mapped properties will be considered optional, even if the mapping
      *              doesn't explicitly specify this, false if the mapping will determine whether a
      *              property is optional or not (default)
@@ -645,9 +649,9 @@ export class JsonConvert {
         }
 
 
-        // Check if the property is optional, or if we're ignoring the optional property
+        // Check if the property is optional
         // If the json value is null, we don't assign it in that case
-        if ((isOptional || this._ignoreRequiredCheck) && classInstancePropertyValue === null) return;
+        if (isOptional && classInstancePropertyValue === null) return;
 
 
         // Map the property
@@ -711,7 +715,7 @@ export class JsonConvert {
 
         // Check if the property is optional
         // If the json value is null, we don't assign it in that case
-        if ((isOptional || this._ignoreRequiredCheck) && jsonValue === null) return;
+        if (isOptional && jsonValue === null) return;
 
 
         // Map the property

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -574,9 +574,6 @@ export class JsonConvert {
         }
 
         // Now deserialize and return the array
-        if (this.operationMode === OperationMode.DISABLE) {
-            return jsonArray;
-        }
         if (this.operationMode === OperationMode.LOGGING) {
             console.log("----------");
             console.log("Receiving JSON array:");

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -148,6 +148,39 @@ export class JsonConvert {
         if (value in PropertyMatchingRule) this._propertyMatchingRule = value;
     }
 
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties when serializing or deserializing will be ignored, as if they
+     * were marked optional.  Defaults to false.
+     */
+    private _ignoreRequiredCheck = false;
+
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties when serializing or deserializing will be ignored, as if they
+     * were marked optional.  Defaults to false.
+     * @returns {boolean} true if all mapped properties will be considered optional, even if the mapping
+     *                    doesn't explicitly specify this, false if the mapping will determine whether
+     *                    a property is optional or not (default)
+     */
+    get ignoreRequiredCheck(): boolean {
+        return this._ignoreRequiredCheck;
+    }
+
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties when serializing or deserializing will be ignored, as if they
+     * were marked optional.  Defaults to false.
+     * @param value true if all mapped properties will be considered optional, even if the mapping
+     *              doesn't explicitly specify this, false if the mapping will determine whether a
+     *              property is optional or not (default)
+     */
+    set ignoreRequiredCheck( value: boolean) {
+        this._ignoreRequiredCheck = value;
+    }
 
     /////////////////
     // CONSTRUCTOR //
@@ -578,7 +611,7 @@ export class JsonConvert {
         // Check if the class property value exists
         if (typeof (classInstancePropertyValue) === "undefined") {
 
-            if (isOptional) return;
+            if (isOptional || this._ignoreRequiredCheck) return;
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -589,9 +622,9 @@ export class JsonConvert {
         }
 
 
-        // Check if the property is optional
+        // Check if the property is optional, or if we're ignoring the optional property
         // If the json value is null, we don't assign it in that case
-        if (isOptional && classInstancePropertyValue === null) return;
+        if ((isOptional || this._ignoreRequiredCheck) && classInstancePropertyValue === null) return;
 
 
         // Map the property
@@ -642,7 +675,7 @@ export class JsonConvert {
         // Check if the json value exists
         if (typeof (jsonValue) === "undefined") {
 
-            if (isOptional) return;
+            if (isOptional || this._ignoreRequiredCheck) return;
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -655,7 +688,7 @@ export class JsonConvert {
 
         // Check if the property is optional
         // If the json value is null, we don't assign it in that case
-        if (isOptional && jsonValue === null) return;
+        if ((isOptional || this._ignoreRequiredCheck) && jsonValue === null) return;
 
 
         // Map the property

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -10,6 +10,7 @@ import { Animal } from "./model/typescript/animal";
 import { IOptionalCat } from './model/json/i-optional-cat';
 import { OptionalCat } from './model/typescript/optional-cat';
 import { IAnimal } from './model/json/i-animal';
+import { DuplicateCat } from './model/typescript/duplicate-cat';
 
 describe('Integration tests', () => {
 
@@ -47,6 +48,15 @@ describe('Integration tests', () => {
         };
         let optionalCatJsonObject: IOptionalCat = {
             catName: "OptionalMeowy"
+        };
+        // DuplicateCat class has no mapped properties, so when serialized JSON should match IAnimal interface
+        let duplicateCat1SerializeJsonObject: IAnimal = {
+            name: "Duplicate"
+        };
+        // Add district property, which exists on DuplicateCat but is not mapped - should not be deserialized
+        let duplicateCat2DeserializeJsonObject = {
+            name: "Duplicate2",
+            district: "2016-02-01"
         };
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
@@ -97,6 +107,13 @@ describe('Integration tests', () => {
         let optionalCat = new OptionalCat();
         optionalCat.name = "OptionalMeowy";
 
+        let duplicateCat1 = new DuplicateCat();
+        duplicateCat1.name = "Duplicate";
+        duplicateCat1.district = new Date("2014-10-01");
+
+        let duplicateCat2 = new DuplicateCat();
+        duplicateCat2.name = "Duplicate2";
+
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
 
@@ -139,9 +156,13 @@ describe('Integration tests', () => {
                 expect(jsonConvert.serialize<Cat>(cat1)).toEqual(cat1JsonObject);
                 expect(jsonConvert.serialize<Cat>(cat2)).toEqual(cat2JsonObject);
                 expect(jsonConvert.serialize<Dog>(dog1)).toEqual(dog1JsonObject);
+                // District property should not be included in serialized JSON
+                expect(jsonConvert.serialize(duplicateCat1)).toEqual(duplicateCat1SerializeJsonObject);
                 expect(jsonConvert.serializeObject<Cat>(cat1)).toEqual(cat1JsonObject);
                 expect(jsonConvert.serializeObject<Cat>(cat2)).toEqual(cat2JsonObject);
                 expect(jsonConvert.serializeObject<Dog>(dog1)).toEqual(dog1JsonObject);
+                // District property should not be included in serialized JSON
+                expect(jsonConvert.serializeObject(duplicateCat1)).toEqual(duplicateCat1SerializeJsonObject);
 
                 expect(() => jsonConvert.serializeArray(<any> cat1)).toThrow();
             });
@@ -211,9 +232,13 @@ describe('Integration tests', () => {
                 expect(jsonConvert.deserialize<Cat>(cat1JsonObject, Cat)).toEqual(cat1);
                 expect(jsonConvert.deserialize<Cat>(cat2JsonObject, Cat)).toEqual(cat2);
                 expect(jsonConvert.deserialize<Dog>(dog1JsonObject, Dog)).toEqual(dog1);
+                // Duplicate property in JSON should be not be deserialized
+                expect(jsonConvert.deserialize(duplicateCat2DeserializeJsonObject, DuplicateCat)).toEqual(duplicateCat2);
                 expect(jsonConvert.deserializeObject<Cat>(cat1JsonObject, Cat)).toEqual(cat1);
                 expect(jsonConvert.deserializeObject<Cat>(cat2JsonObject, Cat)).toEqual(cat2);
                 expect(jsonConvert.deserializeObject<Dog>(dog1JsonObject, Dog)).toEqual(dog1);
+                // Duplicate property in JSON should be not be deserialized
+                expect(jsonConvert.deserializeObject(duplicateCat2DeserializeJsonObject, DuplicateCat)).toEqual(duplicateCat2);
 
                 expect(() => jsonConvert.deserializeArray<Cat>(<any> cat1JsonObject, Cat)).toThrow();
 

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -9,6 +9,7 @@ import { IDog } from "./model/json/i-dog";
 import { Animal } from "./model/typescript/animal";
 import { IOptionalCat } from './model/json/i-optional-cat';
 import { OptionalCat } from './model/typescript/optional-cat';
+import { IAnimal } from './model/json/i-animal';
 
 describe('Integration tests', () => {
 
@@ -50,6 +51,25 @@ describe('Integration tests', () => {
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
 
+        // JSON objects with only Animal base properties
+        let cat1AnimalOnlyJson: IAnimal = {
+            name: "Meowy",
+            owner: human1JsonObject,
+            birthdate: "2016-01-02",
+            friends: []
+        };
+        let cat2AnimalOnlyJson: IAnimal = {
+            name: "Links",
+            birthdate: "2016-01-02"
+        };
+        let dog1AnimalOnlyJson: IAnimal = {
+            name: "Barky",
+            birthdate: "2016-01-02",
+            friends: []
+        };
+        let animalsOnlyJsonArray = [cat1AnimalOnlyJson, dog1AnimalOnlyJson];
+        let catsAnimalOnlyJsonArray = [cat1AnimalOnlyJson, cat2AnimalOnlyJson];
+
         // TYPESCRIPT INSTANCES
         let human1 = new Human();
         human1.firstname = "Andreas";
@@ -80,6 +100,35 @@ describe('Integration tests', () => {
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
 
+        // JSON objects using Typescript mappings
+        let cat1Typescript: any = {
+            name: "Meowy",
+            district: 100,
+            owner: {
+                firstname: "Andreas",
+                lastname: "Muster"
+            },
+            birthdate: new Date("2016-01-02"),
+            friends: [],
+            talky: false,
+            other: ""
+        };
+        let cat2Typescript: any = {
+            name: "Links",
+            district: 50,
+            birthdate: new Date( "2016-01-02" ),
+            talky: true,
+            other: ""
+        };
+        let dogTypescript: any = {
+            name: "Barky",
+            isBarking: true,
+            birthdate: new Date("2016-01-02"),
+            friends: [],
+            other: 0
+        };
+        let animalsTypescript = [cat1Typescript, dogTypescript];
+        let catsTypescript = [cat1Typescript, cat2Typescript];
 
         // SERIALIZE INTEGRATION
         describe('serialize', () => {
@@ -104,6 +153,29 @@ describe('Integration tests', () => {
                 expect(jsonConvert.serializeArray<Cat>(cats)).toEqual(catsJsonArray);
 
                 expect(() => jsonConvert.serializeArray<Cat>(<any> cat1)).toThrow();
+            });
+
+            it('should serialize a plain object using Typescript class mappings', () => {
+                expect(jsonConvert.serialize(cat1Typescript, Cat)).toEqual(cat1JsonObject);
+                expect(jsonConvert.serialize(dogTypescript, Dog)).toEqual(dog1JsonObject);
+                expect(jsonConvert.serializeObject(cat1Typescript, Cat)).toEqual(cat1JsonObject);
+                expect(jsonConvert.serializeObject(dogTypescript, Dog)).toEqual(dog1JsonObject);
+
+                expect(() => jsonConvert.serializeObject(catsTypescript, Cat)).toThrow();
+            });
+
+            it('should serialize a plain array using Typescript class mappings', () => {
+                expect(jsonConvert.serialize(catsTypescript, Animal)).toEqual(catsAnimalOnlyJsonArray);
+                expect(jsonConvert.serialize(catsTypescript, Cat)).toEqual(catsJsonArray);
+                expect(jsonConvert.serialize(animalsTypescript, Animal)).toEqual(animalsOnlyJsonArray);
+                expect(jsonConvert.serializeArray(catsTypescript, Animal)).toEqual(catsAnimalOnlyJsonArray);
+                expect(jsonConvert.serializeArray(catsTypescript, Cat)).toEqual(catsJsonArray);
+                expect(jsonConvert.serializeArray(animalsTypescript, Animal)).toEqual(animalsOnlyJsonArray);
+
+                expect(() => jsonConvert.serializeArray(cat1Typescript, Cat)).toThrow();
+                // Should throw an error if attempting to serialize an array containing a Dog using Cat mappings
+                // because required properties are missing
+                expect(() => jsonConvert.serializeArray(animalsTypescript, Cat)).toThrow();
             });
 
             it('should throw an error if serializing a Typescript object with a missing property', () => {

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -7,6 +7,8 @@ import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
 import { Animal } from "./model/typescript/animal";
+import { IOptionalCat } from './model/json/i-optional-cat';
+import { OptionalCat } from './model/typescript/optional-cat';
 
 describe('Integration tests', () => {
 
@@ -42,6 +44,9 @@ describe('Integration tests', () => {
             talky: true,
             other: ""
         };
+        let optionalCatJsonObject: IOptionalCat = {
+            catName: "OptionalMeowy"
+        };
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
 
@@ -68,6 +73,9 @@ describe('Integration tests', () => {
         cat2.district = 50;
         cat2.birthdate = new Date("2016-01-02");
         cat2.talky = true;
+
+        let optionalCat = new OptionalCat();
+        optionalCat.name = "OptionalMeowy";
 
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
@@ -98,6 +106,28 @@ describe('Integration tests', () => {
                 expect(() => jsonConvert.serializeArray<Cat>(<any> cat1)).toThrow();
             });
 
+            it('should throw an error if serializing a Typescript object with a missing property', () => {
+                expect(function() {jsonConvert.serialize(optionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                    '"district" does not exist or is not defined:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+                expect(function() {jsonConvert.serializeObject(optionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                    '"district" does not exist or is not defined:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+            });
+
+            it('should not throw an error if serializing missing property with ignoreRequiredCheck flag set', () => {
+                jsonConvert.ignoreRequiredCheck = true;
+                expect(jsonConvert.serialize(optionalCat)).toEqual(optionalCatJsonObject);
+                expect(jsonConvert.serializeObject(optionalCat)).toEqual(optionalCatJsonObject);
+                jsonConvert.ignoreRequiredCheck = false;
+            });
+
         });
 
         // DESERIALIZE INTEGRATION
@@ -122,6 +152,27 @@ describe('Integration tests', () => {
                 expect(jsonConvert.deserializeArray<Cat>(catsJsonArray, Cat)).toEqual(cats);
 
                 expect(() => jsonConvert.deserializeObject<Cat>(catsJsonArray, Cat)).toThrow();
+            });
+
+
+            it('should throw an error if deserializing a JSON object with a missing property', () => {
+                expect(function() {jsonConvert.deserialize(optionalCatJsonObject, OptionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JSON object to the class "OptionalKitty" because the defined JSON property "districtNumber" does not exist:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+                expect(function() {jsonConvert.deserializeObject(optionalCatJsonObject, OptionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JSON object to the class "OptionalKitty" because the defined JSON property "districtNumber" does not exist:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+            });
+
+            it('should not throw an error if deserializing missing property with ignoreRequiredCheck flag set', () => {
+                jsonConvert.ignoreRequiredCheck = true;
+                expect(jsonConvert.deserialize(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
+                expect(jsonConvert.deserializeObject(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
+                jsonConvert.ignoreRequiredCheck = false;
             });
 
         });

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -8,6 +8,7 @@ import { Dog } from "./model/typescript/dog";
 import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
+import { OptionalCat } from './model/typescript/optional-cat';
 
 describe('Unit tests', () => {
 
@@ -77,6 +78,10 @@ describe('Unit tests', () => {
         dog1.owner = null;
         dog1.other = 1.1;
 
+        // TYPESCRIPT OPTIONAL INSTANCES
+        let optionalCat1 = new OptionalCat();
+        optionalCat1.name = "MaybeMeowy";
+
         // SETUP CHECKS
         describe('setup checks', () => {
             it('JsonConvert instance', () => {
@@ -87,21 +92,25 @@ describe('Unit tests', () => {
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert(OperationMode.DISABLE, ValueCheckingMode.ALLOW_NULL, true);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.DISABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(true);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert(OperationMode.LOGGING, ValueCheckingMode.DISALLOW_NULL, false);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.LOGGING);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.DISALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert();
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
             });
 
@@ -162,43 +171,88 @@ describe('Unit tests', () => {
 
             jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
 
-            it('serializeObject_loopProperty()', () => {
-                let t_cat = {};
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
-                expect((<any>t_cat)["catName"]).toBe(cat1.name);
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
-                expect((<any>t_cat)["district"]).toBe(100);
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
-                expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
-            });
-            it('deserializeObject_loopProperty()', () => {
-                let t_cat = new Cat();
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catName": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "district", {"district": 100});
-                expect(t_cat.district).toEqual(100);
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "owner", {
-                    "owner": {
-                        givenName: "Andreas",
-                        lastName: "Muster"
-                    }
+            describe('serializeObject_loopProperty()', () => {
+                let t_cat: any;
+                beforeEach( () => {
+                    t_cat = {};
+                } );
+
+                it('should serialize property with different class and JSON names', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
+                    expect((<any>t_cat)["catName"]).toBe(cat1.name);
                 });
-                expect(t_cat.owner!.lastname).toEqual("Muster");
+                it('should serialize property with no declared property name', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
+                    expect((<any>t_cat)["district"]).toBe(100);
+                });
+                it('should serialize a child object property', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
+                    expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
+                });
+                it('should throw an error if required property is missing', () => {
+                    expect( function () {
+                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat )
+                    } ).toThrowError( 'Fatal error in JsonConvert. ' +
+                        'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                        '"district" does not exist or is not defined:\n\n' +
+                        '\tClass property: \n\t\tdistrict\n\n' +
+                        '\tJSON property: \n\t\tdistrictNumber\n\n' );
+                });
+                it('should not throw an error if required property is missing but ignoreRequiredCheck flag set', () => {
+                    jsonConvert.ignoreRequiredCheck = true;
+                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat );
+                    expect( ( <any>t_cat )[ 'district' ] ).toBeUndefined( 'No value set, but no error thrown' );
+                    jsonConvert.ignoreRequiredCheck = false;
+                });
+            });
+            describe('deserializeObject_loopProperty()', () => {
+                let t_cat: Cat;
+                beforeEach( () => {
+                    t_cat = new Cat();
+                } );
 
-                let t_dog = new Dog();
-                (<any>jsonConvert).deserializeObject_loopProperty(t_dog, "name", {"name": "Barky"});
-                expect(t_dog.name).toEqual("Barky");
+                it( 'should deserialize properties', () => {
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catName': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'district', { 'district': 100 } );
+                    expect( t_cat.district ).toEqual( 100 );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'owner', {
+                        'owner': {
+                            givenName: 'Andreas',
+                            lastName: 'Muster'
+                        }
+                    } );
+                    expect( t_cat.owner!.lastname ).toEqual( 'Muster' );
 
-                jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_INSENSITIVE;
+                    let t_dog = new Dog();
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_dog, 'name', { 'name': 'Barky' } );
+                    expect( t_dog.name ).toEqual( 'Barky' );
 
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catName": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catNAME": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                expect(() => (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catNames": "Meowy"})).toThrow();
+                    jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_INSENSITIVE;
 
-                jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_STRICT;
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catName': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catNAME': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    expect( () => ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catNames': 'Meowy' } ) ).toThrow();
 
+                    jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_STRICT;
+                } );
+                it( 'should throw an error if required property is missing', () => {
+                    expect( function () {
+                        ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', {} );
+                    } ).toThrowError( 'Fatal error in JsonConvert. ' +
+                      'Failed to map the JSON object to the class "Kitty" because the defined JSON property "catName" does not exist:\n\n' +
+                      '\tClass property: \n\t\tname\n\n' +
+                      '\tJSON property: \n\t\tcatName\n\n'
+                    );
+                } );
+                it( 'should not throw an error if required property is missing but ignoreRequiredCheck flag is set', () => {
+                    jsonConvert.ignoreRequiredCheck = true;
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', {} );
+                    expect( t_cat.name ).toEqual( '', 'Value not set because not present, default value used' );
+                    jsonConvert.ignoreRequiredCheck = false;
+                } );
             });
 
             jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -164,6 +164,23 @@ describe('Unit tests', () => {
                 let t_catJsonObject = (<any>jsonConvert).serialize(t_cat);
                 expect(t_catJsonObject).toEqual(cat1JsonObject);
             });
+
+            describe('OperationMode', () => {
+                it('should just return the object unchanged with OperationMode.DISABLE', () => {
+                    jsonConvert.operationMode = OperationMode.DISABLE;
+                    expect(jsonConvert.serialize(cat1)).toEqual(cat1);
+                    expect(jsonConvert.serializeObject(cat1)).toEqual(cat1);
+                    expect(jsonConvert.serializeArray([cat1])).toEqual([cat1]);
+                    let t_cat = (<any>jsonConvert).deserialize(cat1JsonObject, Cat);
+                    expect(t_cat).toEqual(cat1JsonObject);
+                    let t_cat2 = (<any>jsonConvert).deserializeObject(cat1JsonObject, Cat);
+                    expect(t_cat2).toEqual(cat1JsonObject);
+                    let t_cat3 = (<any>jsonConvert).deserializeArray([cat1JsonObject], Cat);
+                    expect(t_cat3).toEqual([cat1JsonObject]);
+
+                    jsonConvert.operationMode = OperationMode.ENABLE;
+                });
+            });
         });
 
         // PRIVATE METHODS

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -88,28 +88,32 @@ describe('Unit tests', () => {
 
                 let jsonConvertTest: JsonConvert;
 
-                jsonConvertTest = new JsonConvert(OperationMode.ENABLE, ValueCheckingMode.ALLOW_OBJECT_NULL, false);
+                jsonConvertTest = new JsonConvert(OperationMode.ENABLE, ValueCheckingMode.ALLOW_OBJECT_NULL, false, PropertyMatchingRule.CASE_STRICT);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.propertyMatchingRule).toEqual(PropertyMatchingRule.CASE_STRICT);
                 expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
-                jsonConvertTest = new JsonConvert(OperationMode.DISABLE, ValueCheckingMode.ALLOW_NULL, true);
+                jsonConvertTest = new JsonConvert(OperationMode.DISABLE, ValueCheckingMode.ALLOW_NULL, true, PropertyMatchingRule.CASE_INSENSITIVE);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.DISABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(true);
+                expect(jsonConvertTest.propertyMatchingRule).toEqual(PropertyMatchingRule.CASE_INSENSITIVE);
                 expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert(OperationMode.LOGGING, ValueCheckingMode.DISALLOW_NULL, false);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.LOGGING);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.DISALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.propertyMatchingRule).toEqual(PropertyMatchingRule.CASE_STRICT);
                 expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert();
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.propertyMatchingRule).toEqual(PropertyMatchingRule.CASE_STRICT);
                 expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
             });

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -178,20 +178,20 @@ describe('Unit tests', () => {
                 } );
 
                 it('should serialize property with different class and JSON names', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "name", t_cat);
                     expect((<any>t_cat)["catName"]).toBe(cat1.name);
                 });
                 it('should serialize property with no declared property name', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "district", t_cat);
                     expect((<any>t_cat)["district"]).toBe(100);
                 });
                 it('should serialize a child object property', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "owner", t_cat);
                     expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
                 });
                 it('should throw an error if required property is missing', () => {
                     expect( function () {
-                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat )
+                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, optionalCat1, 'district', t_cat )
                     } ).toThrowError( 'Fatal error in JsonConvert. ' +
                         'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
                         '"district" does not exist or is not defined:\n\n' +
@@ -200,7 +200,7 @@ describe('Unit tests', () => {
                 });
                 it('should not throw an error if required property is missing but ignoreRequiredCheck flag set', () => {
                     jsonConvert.ignoreRequiredCheck = true;
-                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat );
+                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, optionalCat1, 'district', t_cat );
                     expect( ( <any>t_cat )[ 'district' ] ).toBeUndefined( 'No value set, but no error thrown' );
                     jsonConvert.ignoreRequiredCheck = false;
                 });
@@ -259,7 +259,7 @@ describe('Unit tests', () => {
 
             it('serializeObject_loopProperty()', () => {
                 let t_cat = {};
-                (<any>jsonConvert).serializeObject_loopProperty(cat2, "owner", t_cat);
+                (<any>jsonConvert).serializeObject_loopProperty(cat2, cat2, "owner", t_cat);
                 expect((<any>t_cat)["owner"]).toBe(undefined);
             });
             it('deserializeObject_loopProperty()', () => {

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -127,15 +127,29 @@ describe('Unit tests', () => {
 
                 jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
 
-                let t_cat = (<any>jsonConvert).deserialize(null, Cat);
-                expect(t_cat).toEqual(null);
-                let t_catJsonObject = (<any>jsonConvert).serialize(null);
-                expect(t_catJsonObject).toEqual(null);
+                let t_cat1 = (<any>jsonConvert).deserialize(null, Cat);
+                expect(t_cat1).toEqual(null);
+                let t_cat2 = (<any>jsonConvert).deserializeObject(null, Cat);
+                expect(t_cat2).toEqual(null);
+                let t_cat3 = (<any>jsonConvert).deserializeArray(null, Cat);
+                expect(t_cat3).toEqual(null);
+
+                let t_catJsonObject1 = (<any>jsonConvert).serialize(null);
+                expect(t_catJsonObject1).toEqual(null);
+                let t_catJsonObject2 = (<any>jsonConvert).serializeObject(null);
+                expect(t_catJsonObject2).toEqual(null);
+                let t_catJsonObject3 = (<any>jsonConvert).serializeArray(null);
+                expect(t_catJsonObject3).toEqual(null);
 
                 jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;
 
                 expect(() => (<any>jsonConvert).deserialize(null, Cat)).toThrow();
+                expect(() => (<any>jsonConvert).deserializeObject(null, Cat)).toThrow();
+                expect(() => (<any>jsonConvert).deserializeArray(null, Cat)).toThrow();
+
                 expect(() => (<any>jsonConvert).serialize(null)).toThrow();
+                expect(() => (<any>jsonConvert).serializeObject(null)).toThrow();
+                expect(() => (<any>jsonConvert).serializeArray(null)).toThrow();
 
             });
             it('deserialize and serialize undefined', () => {
@@ -143,7 +157,12 @@ describe('Unit tests', () => {
                 jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
 
                 expect(() => (<any>jsonConvert).deserialize(undefined, Cat)).toThrowError();
+                expect(() => (<any>jsonConvert).deserializeObject(undefined, Cat)).toThrowError();
+                expect(() => (<any>jsonConvert).deserializeArray(undefined, Cat)).toThrowError();
+
                 expect(() => (<any>jsonConvert).serialize(undefined)).toThrowError();
+                expect(() => (<any>jsonConvert).serializeObject(undefined)).toThrowError();
+                expect(() => (<any>jsonConvert).serializeArray(undefined)).toThrowError();
 
             });
         });

--- a/test/model/json/i-animal.ts
+++ b/test/model/json/i-animal.ts
@@ -1,0 +1,6 @@
+export interface IAnimal {
+  name: string;
+  owner?: object | null;
+  birthdate?: string;
+  friends?: any[];
+}

--- a/test/model/json/i-optional-cat.ts
+++ b/test/model/json/i-optional-cat.ts
@@ -1,0 +1,7 @@
+export interface IOptionalCat {
+    catName: string;
+    owner?: object | null;
+    birthdate?: string | null;
+    friends?: any[] | null;
+    district?: number;
+}

--- a/test/model/typescript/date-converter.ts
+++ b/test/model/typescript/date-converter.ts
@@ -7,7 +7,7 @@ export class DateConverter implements JsonCustomConvert<Date | null> {
         if (date instanceof Date) {
             let year = date.getFullYear();
             let month = date.getMonth() + 1;
-            let day = date.getDate();
+            let day = date.getUTCDate();
             return year + "-" + (month < 10 ? "0" + month : month) + "-" + (day < 10 ? "0" + day : day);
         } else {
             return null;

--- a/test/model/typescript/duplicate-cat.ts
+++ b/test/model/typescript/duplicate-cat.ts
@@ -1,0 +1,15 @@
+import { Animal } from './animal';
+import { JsonObject } from '../../../src/json2typescript/json-convert-decorators';
+
+/**
+ * Class which has a property with the same name as Cat.  Used to test handling
+ * of prototype-based property mapping search.  Property has the same name, but
+ * an incompatible type, and is initialized (so it's present) but purposely left
+ * unmapped, so it shouldn't be serialized or deserialized.
+ */
+@JsonObject("DuplicateCat")
+export class DuplicateCat extends Animal {
+
+  // Leave property with the same name unmapped so there's no direct mapping, but use an incompatible type
+  district: Date | undefined = undefined;
+}

--- a/test/model/typescript/optional-cat.ts
+++ b/test/model/typescript/optional-cat.ts
@@ -1,0 +1,14 @@
+import { JsonObject, JsonProperty } from "../../../src/json2typescript/json-convert-decorators";
+
+import { Animal } from "./animal";
+
+@JsonObject("OptionalKitty")
+export class OptionalCat extends Animal {
+
+    @JsonProperty("catName", String)
+    name: string = "";
+
+    @JsonProperty("districtNumber", Number)
+    district?: number = undefined;
+
+}


### PR DESCRIPTION
This is a great library overall!

However, I have a somewhat specific use case which the library doesn't currently match.  I have a large class with defined property mappings whose values are filled in through multiple Angular reactive forms.  The forms basically match the structure of the class, and include some values which are objects (like Dates), that I'd like to use my pre-defined mappings for.  However, there are 2 problems:

- The form output is not itself an instance of the mapped class, so doesn't have any defined property mappings.
- Because the object is filled in using multiple forms, the output may not include values for all the "required" fields that I expect when deserializing a full object.

To addresss this, I've added 2 features:

- New ignoreRequiredCheck flag which effectively makes all properties optional, even if the property mapping doesn't specify isOptional = true. (commit 3b34cc3)
- Added optional classReference parameters to all serialization methods, to allow serialization of an object using mappings from the specified class reference instead of mappings from the object itself. (commit c0591fd)

I've added/updated tests to include these new features, and added some test fixes/expansions as well.  (For example, if the current tests are run west of GMT, they'll fail because of the way the test DateConverter is implemented.)

Note that adding the new optional classReference parameters to the serialization methods means that the data object parameters must now accept "any" instead of the specific generic class instance.