### PR TITLE
Fixed property mapping to be inheritance-based

### DIFF
--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -695,16 +695,18 @@ export class JsonConvert {
         // Check if mapping is defined
         if (typeof (mappings) === "undefined") return null;
 
-        // Get direct mapping if possible
-        const directMappingName: string = instance[Settings.CLASS_IDENTIFIER] + "." + propertyName;
-        if (typeof (mappings[directMappingName]) !== "undefined") {
-            return mappings[directMappingName];
-        }
-
-        // No mapping was found, try to find some
-        const indirectMappingNames: string[] = Object.keys(mappings).filter(key => key.match("\\." + propertyName + "$")); // use endsWidth in later versions
-        if (indirectMappingNames.length > 0) {
-            return mappings[indirectMappingNames[0]];
+        /* Find mapping by iterating up the prototype chain to find a matching mapping, rather than
+         * just searching by property name. */
+        let prototype = Object.getPrototypeOf(instance);
+        while (prototype != null) {
+            const classIdentifier = prototype[Settings.CLASS_IDENTIFIER];
+            if (!!classIdentifier) {
+                const mappingName: string = classIdentifier + "." + propertyName;
+                if (typeof (mappings[mappingName]) !== "undefined") {
+                    return mappings[mappingName];
+                }
+            }
+            prototype = Object.getPrototypeOf(prototype);
         }
 
         return null;

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -698,7 +698,11 @@ export class JsonConvert {
         /* Find mapping by iterating up the prototype chain to find a matching mapping, rather than
          * just searching by property name. */
         let prototype = Object.getPrototypeOf(instance);
-        while (prototype != null) {
+        /* According to documentation, we'll hit null when we've iterated all the way up to the base
+         * Object, but check for undefined as well in case prototype has been manually set to
+         * undefined.  Note that javascript detects circular prototype references and will cause a
+         * TypeError, so no need to check for self, the prototype chain will eventually terminate. */
+        while (prototype !== null && prototype !== undefined) {
             const classIdentifier = prototype[Settings.CLASS_IDENTIFIER];
             if (!!classIdentifier) {
                 const mappingName: string = classIdentifier + "." + propertyName;

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -1,5 +1,5 @@
 import { JsonConvert } from "../src/json2typescript/json-convert";
-import { OperationMode, ValueCheckingMode } from "../src/json2typescript/json-convert-enums";
+import { ValueCheckingMode } from "../src/json2typescript/json-convert-enums";
 import { Cat } from "./model/typescript/cat";
 import { Human } from "./model/typescript/human";
 import { Dog } from "./model/typescript/dog";
@@ -7,8 +7,8 @@ import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
 import { Animal } from "./model/typescript/animal";
-import { IAnimal } from "./model/json/i-animal";
 import { DuplicateCat } from "./model/typescript/duplicate-cat";
+import { IDuplicateCat } from "./model/json/i-duplicate-cat";
 
 describe('Integration tests', () => {
 
@@ -44,14 +44,15 @@ describe('Integration tests', () => {
             talky: true,
             other: ""
         };
-        // DuplicateCat class has no mapped properties, so when serialized JSON should match IAnimal interface
-        let duplicateCat1SerializeJsonObject: IAnimal = {
-            name: "Duplicate"
+        let duplicateCat1SerializeJsonObject: IDuplicateCat = {
+            name: "Duplicate",
+            talky: "2015-02-03"
         };
         // Add district property, which exists on DuplicateCat but is not mapped - should not be deserialized
         let duplicateCat2DeserializeJsonObject = {
             name: "Duplicate2",
-            district: "2016-02-01"
+            district: "2016-02-01",
+            talky: "2016-03-04"
         };
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
@@ -83,9 +84,11 @@ describe('Integration tests', () => {
         let duplicateCat1 = new DuplicateCat();
         duplicateCat1.name = "Duplicate";
         duplicateCat1.district = new Date("2014-10-01");
+        duplicateCat1.talky = new Date("2015-02-03");
 
         let duplicateCat2 = new DuplicateCat();
         duplicateCat2.name = "Duplicate2";
+        duplicateCat2.talky = new Date("2016-03-04");
 
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -7,6 +7,8 @@ import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
 import { Animal } from "./model/typescript/animal";
+import { IAnimal } from "./model/json/i-animal";
+import { DuplicateCat } from "./model/typescript/duplicate-cat";
 
 describe('Integration tests', () => {
 
@@ -42,6 +44,15 @@ describe('Integration tests', () => {
             talky: true,
             other: ""
         };
+        // DuplicateCat class has no mapped properties, so when serialized JSON should match IAnimal interface
+        let duplicateCat1SerializeJsonObject: IAnimal = {
+            name: "Duplicate"
+        };
+        // Add district property, which exists on DuplicateCat but is not mapped - should not be deserialized
+        let duplicateCat2DeserializeJsonObject = {
+            name: "Duplicate2",
+            district: "2016-02-01"
+        };
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
 
@@ -69,6 +80,13 @@ describe('Integration tests', () => {
         cat2.birthdate = new Date("2016-01-02");
         cat2.talky = true;
 
+        let duplicateCat1 = new DuplicateCat();
+        duplicateCat1.name = "Duplicate";
+        duplicateCat1.district = new Date("2014-10-01");
+
+        let duplicateCat2 = new DuplicateCat();
+        duplicateCat2.name = "Duplicate2";
+
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
 
@@ -82,9 +100,13 @@ describe('Integration tests', () => {
                 expect(jsonConvert.serialize<Cat>(cat1)).toEqual(cat1JsonObject);
                 expect(jsonConvert.serialize<Cat>(cat2)).toEqual(cat2JsonObject);
                 expect(jsonConvert.serialize<Dog>(dog1)).toEqual(dog1JsonObject);
+                // District property should not be included in serialized JSON
+                expect(jsonConvert.serialize(duplicateCat1)).toEqual(duplicateCat1SerializeJsonObject);
                 expect(jsonConvert.serializeObject<Cat>(cat1)).toEqual(cat1JsonObject);
                 expect(jsonConvert.serializeObject<Cat>(cat2)).toEqual(cat2JsonObject);
                 expect(jsonConvert.serializeObject<Dog>(dog1)).toEqual(dog1JsonObject);
+                // District property should not be included in serialized JSON
+                expect(jsonConvert.serializeObject(duplicateCat1)).toEqual(duplicateCat1SerializeJsonObject);
 
                 expect(() => jsonConvert.serializeArray(<any> cat1)).toThrow();
             });
@@ -109,9 +131,13 @@ describe('Integration tests', () => {
                 expect(jsonConvert.deserialize<Cat>(cat1JsonObject, Cat)).toEqual(cat1);
                 expect(jsonConvert.deserialize<Cat>(cat2JsonObject, Cat)).toEqual(cat2);
                 expect(jsonConvert.deserialize<Dog>(dog1JsonObject, Dog)).toEqual(dog1);
+                // Duplicate property in JSON should be not be deserialized
+                expect(jsonConvert.deserialize(duplicateCat2DeserializeJsonObject, DuplicateCat)).toEqual(duplicateCat2);
                 expect(jsonConvert.deserializeObject<Cat>(cat1JsonObject, Cat)).toEqual(cat1);
                 expect(jsonConvert.deserializeObject<Cat>(cat2JsonObject, Cat)).toEqual(cat2);
                 expect(jsonConvert.deserializeObject<Dog>(dog1JsonObject, Dog)).toEqual(dog1);
+                // Duplicate property in JSON should be not be deserialized
+                expect(jsonConvert.deserializeObject(duplicateCat2DeserializeJsonObject, DuplicateCat)).toEqual(duplicateCat2);
 
                 expect(() => jsonConvert.deserializeArray<Cat>(<any> cat1JsonObject, Cat)).toThrow();
 

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -1,14 +1,14 @@
 import { JsonConvert } from "../src/json2typescript/json-convert";
 import { OperationMode, PropertyMatchingRule, ValueCheckingMode } from "../src/json2typescript/json-convert-enums";
 import { Any } from "../src/json2typescript/any";
-import { MappingOptions, Settings } from '../src/json2typescript/json-convert-options';
+import { MappingOptions, Settings } from "../src/json2typescript/json-convert-options";
 import { Human } from "./model/typescript/human";
 import { Cat } from "./model/typescript/cat";
 import { Dog } from "./model/typescript/dog";
 import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
-import { DuplicateCat } from './model/typescript/duplicate-cat';
+import { DuplicateCat } from "./model/typescript/duplicate-cat";
 import { DateConverter } from "./model/typescript/date-converter";
 
 describe('Unit tests', () => {

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -9,6 +9,7 @@ import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
 import { DuplicateCat } from './model/typescript/duplicate-cat';
+import { DateConverter } from "./model/typescript/date-converter";
 
 describe('Unit tests', () => {
 
@@ -81,6 +82,7 @@ describe('Unit tests', () => {
         let duplicateCat1 = new DuplicateCat();
         duplicateCat1.name = "Duplicate";
         duplicateCat1.district = new Date("2014-10-01");
+        duplicateCat1.talky = new Date("2015-02-03");
 
         // SETUP CHECKS
         describe('setup checks', () => {
@@ -246,6 +248,16 @@ describe('Unit tests', () => {
                 dogNameMapping.isOptional = false;
                 dogNameMapping.customConverter = null;
                 expect((<any>jsonConvert).getClassPropertyMappingOptions(dog1, "name")).toEqual(dogNameMapping);
+
+                // Check that mapped property on "sibling" DuplicateCat class with same name as Cat property
+                // but different type is handled correctly
+                const duplicateCatTalkyMapping = new MappingOptions();
+                duplicateCatTalkyMapping.classPropertyName = "talky";
+                duplicateCatTalkyMapping.jsonPropertyName = "talky";
+                duplicateCatTalkyMapping.expectedJsonType = undefined;
+                duplicateCatTalkyMapping.isOptional = false;
+                duplicateCatTalkyMapping.customConverter = new DateConverter();
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(duplicateCat1, "talky")).toEqual(duplicateCatTalkyMapping);
 
                 expect((<any>jsonConvert).getClassPropertyMappingOptions(human1, "name")).toBeNull();
                 // Unmapped property should not return mapping, even though property is the same name as a mapped property on another class

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -1,13 +1,14 @@
 import { JsonConvert } from "../src/json2typescript/json-convert";
 import { OperationMode, PropertyMatchingRule, ValueCheckingMode } from "../src/json2typescript/json-convert-enums";
 import { Any } from "../src/json2typescript/any";
-import { Settings } from "../src/json2typescript/json-convert-options";
+import { MappingOptions, Settings } from '../src/json2typescript/json-convert-options';
 import { Human } from "./model/typescript/human";
 import { Cat } from "./model/typescript/cat";
 import { Dog } from "./model/typescript/dog";
 import { IHuman } from "./model/json/i-human";
 import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
+import { DuplicateCat } from './model/typescript/duplicate-cat';
 
 describe('Unit tests', () => {
 
@@ -76,6 +77,10 @@ describe('Unit tests', () => {
         dog1.isBarking = true;
         dog1.owner = null;
         dog1.other = 1.1;
+
+        let duplicateCat1 = new DuplicateCat();
+        duplicateCat1.name = "Duplicate";
+        duplicateCat1.district = new Date("2014-10-01");
 
         // SETUP CHECKS
         describe('setup checks', () => {
@@ -223,9 +228,28 @@ describe('Unit tests', () => {
             jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
 
             it('getClassPropertyMappingOptions()', () => {
-                expect((<any>jsonConvert).getClassPropertyMappingOptions(cat1, "name")).not.toBeNull();
-                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog1, "name")).not.toBeNull();
+                /* The actual JSON types used are not strings, even though MappingOption.expectedJsonType is typed as string,
+                 * so obscure this by assigning the expected JSON type to an "any" variable. */
+                let jsonType: any = String;
+                const catNameMapping = new MappingOptions();
+                catNameMapping.classPropertyName = "name";
+                catNameMapping.jsonPropertyName = "catName";
+                catNameMapping.expectedJsonType = jsonType;
+                catNameMapping.isOptional = false;
+                catNameMapping.customConverter = null;
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(cat1, "name")).toEqual(catNameMapping);
+
+                const dogNameMapping = new MappingOptions();
+                dogNameMapping.classPropertyName = "name";
+                dogNameMapping.jsonPropertyName = "name";
+                dogNameMapping.expectedJsonType = jsonType;
+                dogNameMapping.isOptional = false;
+                dogNameMapping.customConverter = null;
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog1, "name")).toEqual(dogNameMapping);
+
                 expect((<any>jsonConvert).getClassPropertyMappingOptions(human1, "name")).toBeNull();
+                // Unmapped property should not return mapping, even though property is the same name as a mapped property on another class
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(duplicateCat1, "district")).toBeNull();
             });
             it('verifyProperty()', () => {
                 expect((<any>jsonConvert).verifyProperty(String, "Andreas", false)).toBe("Andreas");

--- a/test/model/json/i-animal.ts
+++ b/test/model/json/i-animal.ts
@@ -1,0 +1,6 @@
+export interface IAnimal {
+  name: string;
+  owner?: object | null;
+  birthdate?: string;
+  friends?: any[];
+}

--- a/test/model/json/i-duplicate-cat.ts
+++ b/test/model/json/i-duplicate-cat.ts
@@ -1,0 +1,5 @@
+import { IAnimal } from "./i-animal";
+
+export interface IDuplicateCat extends IAnimal {
+  talky: string;
+}

--- a/test/model/typescript/date-converter.ts
+++ b/test/model/typescript/date-converter.ts
@@ -7,7 +7,7 @@ export class DateConverter implements JsonCustomConvert<Date | null> {
         if (date instanceof Date) {
             let year = date.getFullYear();
             let month = date.getMonth() + 1;
-            let day = date.getDate();
+            let day = date.getUTCDate();
             return year + "-" + (month < 10 ? "0" + month : month) + "-" + (day < 10 ? "0" + day : day);
         } else {
             return null;

--- a/test/model/typescript/duplicate-cat.ts
+++ b/test/model/typescript/duplicate-cat.ts
@@ -1,5 +1,6 @@
-import { Animal } from './animal';
-import { JsonObject } from '../../../src/json2typescript/json-convert-decorators';
+import { Animal } from "./animal";
+import { JsonObject, JsonProperty } from "../../../src/json2typescript/json-convert-decorators";
+import { DateConverter } from "./date-converter";
 
 /**
  * Class which has a property with the same name as Cat.  Used to test handling
@@ -12,4 +13,8 @@ export class DuplicateCat extends Animal {
 
   // Leave property with the same name unmapped so there's no direct mapping, but use an incompatible type
   district: Date | undefined = undefined;
+
+  // Map other property with same name, but again use an incompatible type
+  @JsonProperty( "talky", DateConverter )
+  talky: Date | undefined = undefined;
 }

--- a/test/model/typescript/duplicate-cat.ts
+++ b/test/model/typescript/duplicate-cat.ts
@@ -1,0 +1,15 @@
+import { Animal } from './animal';
+import { JsonObject } from '../../../src/json2typescript/json-convert-decorators';
+
+/**
+ * Class which has a property with the same name as Cat.  Used to test handling
+ * of prototype-based property mapping search.  Property has the same name, but
+ * an incompatible type, and is initialized (so it's present) but purposely left
+ * unmapped, so it shouldn't be serialized or deserialized.
+ */
+@JsonObject("DuplicateCat")
+export class DuplicateCat extends Animal {
+
+  // Leave property with the same name unmapped so there's no direct mapping, but use an incompatible type
+  district: Date | undefined = undefined;
+}


### PR DESCRIPTION
Modified getClassPropertyMappingOptions() to step through the prototpe chain to find the appropriate property mapping rather than just searching by property name.  That way properties with the same name on different classes won't conflict.  

Also added new test classes and updated unit/integration tests.