### PR TITLE
Feature: new ignoreRequiredCheck flag, and serialize objects using specified class mappings

### DIFF
--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -148,6 +148,43 @@ export class JsonConvert {
         if (value in PropertyMatchingRule) this._propertyMatchingRule = value;
     }
 
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties when serializing or deserializing will be ignored, as if they
+     * were marked optional.  Defaults to false.
+     */
+    private _ignoreRequiredCheck = false;
+
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties (undefined) when serializing or deserializing will be
+     * ignored, as if they were marked optional.  Note that properties explicitly set to null
+     * will be unaffected by this flag - they will be ignored if optional and included if not.
+     * Defaults to false.
+     * @returns {boolean} true if all mapped properties will be considered optional, even if the mapping
+     *                    doesn't explicitly specify this, false if the mapping will determine whether
+     *                    a property is optional or not (default)
+     */
+    get ignoreRequiredCheck(): boolean {
+        return this._ignoreRequiredCheck;
+    }
+
+    /**
+     * Determines whether the check for "required" properties should be ignored, making ALL
+     * mapped values optional, whether or not the isOptional property mapping parameter is set.
+     * If true, any missing properties (undefined) when serializing or deserializing will be
+     * ignored, as if they were marked optional.  Note that properties explicitly set to null
+     * will be unaffected by this flag - they will be ignored if optional and included if not.
+     * Defaults to false.
+     * @param value true if all mapped properties will be considered optional, even if the mapping
+     *              doesn't explicitly specify this, false if the mapping will determine whether a
+     *              property is optional or not (default)
+     */
+    set ignoreRequiredCheck( value: boolean) {
+        this._ignoreRequiredCheck = value;
+    }
 
     /////////////////
     // CONSTRUCTOR //
@@ -598,7 +635,7 @@ export class JsonConvert {
         // Check if the class property value exists
         if (typeof (classInstancePropertyValue) === "undefined") {
 
-            if (isOptional) return;
+            if (isOptional || this._ignoreRequiredCheck) return;
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -662,7 +699,7 @@ export class JsonConvert {
         // Check if the json value exists
         if (typeof (jsonValue) === "undefined") {
 
-            if (isOptional) return;
+            if (isOptional || this._ignoreRequiredCheck) return;
 
             throw new Error(
                 "Fatal error in JsonConvert. " +

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -215,9 +215,15 @@ export class JsonConvert {
 
 
     /**
-     * Tries to serialize a TypeScript object or array of objects to JSON.
+     * Tries to serialize a TypeScript object or array of objects to JSON using the mappings defined on
+     * the specified class reference.  Note that if a class reference is provided, it will be used as
+     * the source of property mapping for serialization, even if the object or one of its elements is
+     * an instance of a different class with its own mappings.  Also, ONLY the properties from the
+     * class reference will be serialized - any additional properties on the object(s) will be silently
+     * ignored.
      *
      * @param data object or array of objects
+     * @param classReference the class reference which provides the property mappings to use
      *
      * @returns the JSON object
      *
@@ -226,7 +232,7 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serialize<T>(data: T | T[]): any | any[] {
+    serialize<T>(data: any | any[], classReference?: { new(): T }): any | any[] {
 
         if (this.operationMode === OperationMode.DISABLE) {
             return data;
@@ -234,23 +240,29 @@ export class JsonConvert {
 
         // Call the appropriate method depending on the type
         if (data instanceof Array) {
-            return this.serializeArray(data);
+            return this.serializeArray(data, classReference);
         } else if (typeof data === "object") { // careful: an array is an object in TypeScript!
-            return this.serializeObject(data);
+            return this.serializeObject(data, classReference);
         } else {
             throw new Error(
-                "Fatal error in JsonConvert. " +
-                "Passed parameter data in JsonConvert.serialize() is not in valid format (object or array)." +
-                "\n"
+              "Fatal error in JsonConvert. " +
+              "Passed parameter data in JsonConvert.serialize() is not in valid format (object or array)." +
+              "\n"
             );
         }
-
     }
 
     /**
-     * Tries to serialize a TypeScript object to a JSON object.
+     * Tries to serialize a TypeScript object to a JSON object using either the mappings on the
+     * provided class reference, if present, or on the provided object.  Note that if a class
+     * reference is provided, it will be used as the source of property mapping for serialization,
+     * even if the object is itself an instance of a different class with its own mappings.
+     * Also, ONLY the properties from the class reference will be serialized - any additional
+     * properties on the object will be silently ignored.
      *
-     * @param instance TypeScript instance
+     * @param data object containing the values to be mapped to a JSON object, must be an
+     *             instance of a class with JSON mappings if no class reference is provided
+     * @param classReference optional class reference which provides the property mappings to use
      *
      * @returns the JSON object
      *
@@ -259,14 +271,14 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serializeObject<T>(instance: T): any {
+    serializeObject<T>(data: any, classReference?: { new(): T }): any {
 
         if (this.operationMode === OperationMode.DISABLE) {
-            return instance;
+            return data;
         }
 
         // Check if the passed type is allowed
-        if (instance === undefined) {
+        if (data === undefined) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -274,7 +286,7 @@ export class JsonConvert {
                 "\n"
             );
 
-        } else if (instance === null) {
+        } else if (data === null) {
 
             if (this.valueCheckingMode === ValueCheckingMode.DISALLOW_NULL) {
                 throw new Error(
@@ -283,10 +295,10 @@ export class JsonConvert {
                     "\n"
                 );
             } else {
-                return instance;
+                return data;
             }
 
-        } else if (typeof (instance) !== "object" || instance instanceof Array) {
+        } else if (typeof (data) !== "object" || data instanceof Array) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -300,15 +312,21 @@ export class JsonConvert {
         if (this.operationMode === OperationMode.LOGGING) {
             console.log("----------");
             console.log("Receiving JavaScript instance:");
-            console.log(instance);
+            console.log(data);
         }
 
         let jsonObject: any = {};
+        let instance: T;
+        if (!!classReference) {
+            instance = new classReference();
+        } else {
+            instance = <T>data;
+        }
 
-        // Loop through all initialized class properties
+        // Loop through all initialized class properties on the mapping instance
         for (const propertyKey of Object.keys(instance)) {
             try {
-                this.serializeObject_loopProperty(instance, propertyKey, jsonObject);
+                this.serializeObject_loopProperty(data, instance, propertyKey, jsonObject);
             }
             catch (ex) {
                 if (this.operationMode === OperationMode.LOGGING) {
@@ -331,9 +349,16 @@ export class JsonConvert {
     }
 
     /**
-     * Tries to serialize a TypeScript array to a JSON array.
+     * Tries to serialize a TypeScript array to a JSON array using either the mappings on the
+     * provided class reference, if present, or on the provided object.  Note that if a class
+     * reference is provided, ALL objects in the array will be serialized using the mappings
+     * from that class reference, even if they're actually instances of a different class.
+     * Also, ONLY the properties from the class reference will be serialized - any additional
+     * properties on the objects will be silently ignored.
      *
-     * @param instanceArray array of TypeScript instances
+     * @param dataArray array of objects containing the values to be mapped to a JSON object, which
+     *                  must be instances of classes with JSON mappings if no class reference is provided
+     * @param classReference optional class reference which provides the property mappings to use
      *
      * @returns the JSON array
      *
@@ -342,14 +367,14 @@ export class JsonConvert {
      * @author Andreas Aeschlimann, DHlab, University of Basel, Switzerland
      * @see https://www.npmjs.com/package/json2typescript full documentation
      */
-    serializeArray<T>(instanceArray: T[]): any[] {
+    serializeArray<T>(dataArray: any[], classReference?: { new(): T }): any[] {
 
         if (this.operationMode === OperationMode.DISABLE) {
-            return instanceArray;
+            return dataArray;
         }
 
         // Check if the passed type is allowed
-        if (instanceArray === undefined) {
+        if (dataArray === undefined) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -357,7 +382,7 @@ export class JsonConvert {
                 "\n"
             );
 
-        } else if (instanceArray === null) {
+        } else if (dataArray === null) {
 
             if (this.valueCheckingMode === ValueCheckingMode.DISALLOW_NULL) {
                 throw new Error(
@@ -366,10 +391,10 @@ export class JsonConvert {
                     "\n"
                 );
             } else {
-                return instanceArray;
+                return dataArray;
             }
 
-        } else if (typeof (instanceArray) !== "object" || instanceArray instanceof Array === false) {
+        } else if (typeof (dataArray) !== "object" || dataArray instanceof Array === false) {
 
             throw new Error(
                 "Fatal error in JsonConvert. " +
@@ -383,14 +408,14 @@ export class JsonConvert {
         if (this.operationMode === OperationMode.LOGGING) {
             console.log("----------");
             console.log("Receiving JavaScript array:");
-            console.log(instanceArray);
+            console.log(dataArray);
         }
 
         let jsonArray: any[] = [];
 
         // Loop through all array elements
-        for (const classInstance of <any> instanceArray) {
-            jsonArray.push(this.serializeObject(classInstance));
+        for (const dataObject of <any> dataArray) {
+            jsonArray.push(this.serializeObject(dataObject, classReference));
         }
 
         if (this.operationMode === OperationMode.LOGGING) {
@@ -606,15 +631,16 @@ export class JsonConvert {
 
 
     /**
-     * Tries to find the JSON mapping for a given class property and finally assign the value.
+     * Tries to find the JSON mapping for a given class property from the given instance used for mapping,
+     * and finally assign the value from the given dataObject
      *
-     * @param instance the instance of the class
+     * @param dataObject the object containing the value to be assigned
+     * @param instance the instance of the class used for mapping
      * @param classPropertyName the property name
      * @param json the JSON object
-     *
      * @throws throws an Error in case of failure
      */
-    private serializeObject_loopProperty(instance: any, classPropertyName: string, json: any): void {
+    private serializeObject_loopProperty(dataObject: any, instance: any, classPropertyName: string, json: any): void {
 
         // Check if a JSON-object mapping is possible for a property
         const mappingOptions: MappingOptions | null = this.getClassPropertyMappingOptions(instance, classPropertyName);
@@ -629,7 +655,7 @@ export class JsonConvert {
         let isOptional: boolean = mappingOptions.isOptional;
         let customConverter: any = mappingOptions.customConverter;
 
-        let classInstancePropertyValue: any = instance[classPropertyName];
+        let classInstancePropertyValue: any = dataObject[classPropertyName];
 
 
         // Check if the class property value exists
@@ -806,7 +832,7 @@ export class JsonConvert {
                     else throw new Error("\tReason: Given value is null.");
                 }
 
-                if (serialize) return this.serializeObject(value);
+                if (serialize) return this.serializeObject(value, expectedJsonType);
                 else return this.deserializeObject(value, expectedJsonType);
 
             } else if (expectedJsonType === Any || expectedJsonType === null || expectedJsonType === Object) { // general object

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -9,6 +9,8 @@ import { IDog } from "./model/json/i-dog";
 import { Animal } from "./model/typescript/animal";
 import { DuplicateCat } from "./model/typescript/duplicate-cat";
 import { IDuplicateCat } from "./model/json/i-duplicate-cat";
+import { IOptionalCat } from './model/json/i-optional-cat';
+import { OptionalCat } from './model/typescript/optional-cat';
 
 describe('Integration tests', () => {
 
@@ -54,6 +56,9 @@ describe('Integration tests', () => {
             district: "2016-02-01",
             talky: "2016-03-04"
         };
+        let optionalCatJsonObject: IOptionalCat = {
+            catName: "OptionalMeowy"
+        };
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
 
@@ -90,6 +95,9 @@ describe('Integration tests', () => {
         duplicateCat2.name = "Duplicate2";
         duplicateCat2.talky = new Date("2016-03-04");
 
+        let optionalCat = new OptionalCat();
+        optionalCat.name = "OptionalMeowy";
+
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
 
@@ -123,6 +131,28 @@ describe('Integration tests', () => {
                 expect(() => jsonConvert.serializeArray<Cat>(<any> cat1)).toThrow();
             });
 
+            it('should throw an error if serializing a Typescript object with a missing property', () => {
+                expect(function() {jsonConvert.serialize(optionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                    '"district" does not exist or is not defined:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+                expect(function() {jsonConvert.serializeObject(optionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                    '"district" does not exist or is not defined:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+            });
+
+            it('should not throw an error if serializing missing property with ignoreRequiredCheck flag set', () => {
+                jsonConvert.ignoreRequiredCheck = true;
+                expect(jsonConvert.serialize(optionalCat)).toEqual(optionalCatJsonObject);
+                expect(jsonConvert.serializeObject(optionalCat)).toEqual(optionalCatJsonObject);
+                jsonConvert.ignoreRequiredCheck = false;
+            });
+
         });
 
         // DESERIALIZE INTEGRATION
@@ -151,6 +181,27 @@ describe('Integration tests', () => {
                 expect(jsonConvert.deserializeArray<Cat>(catsJsonArray, Cat)).toEqual(cats);
 
                 expect(() => jsonConvert.deserializeObject<Cat>(catsJsonArray, Cat)).toThrow();
+            });
+
+
+            it('should throw an error if deserializing a JSON object with a missing property', () => {
+                expect(function() {jsonConvert.deserialize(optionalCatJsonObject, OptionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JSON object to the class "OptionalKitty" because the defined JSON property "districtNumber" does not exist:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+                expect(function() {jsonConvert.deserializeObject(optionalCatJsonObject, OptionalCat);})
+                  .toThrowError('Fatal error in JsonConvert. ' +
+                    'Failed to map the JSON object to the class "OptionalKitty" because the defined JSON property "districtNumber" does not exist:\n\n' +
+                    '\tClass property: \n\t\tdistrict\n\n' +
+                    '\tJSON property: \n\t\tdistrictNumber\n\n');
+            });
+
+            it('should not throw an error if deserializing missing property with ignoreRequiredCheck flag set', () => {
+                jsonConvert.ignoreRequiredCheck = true;
+                expect(jsonConvert.deserialize(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
+                expect(jsonConvert.deserializeObject(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
+                jsonConvert.ignoreRequiredCheck = false;
             });
 
         });

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -11,6 +11,7 @@ import { DuplicateCat } from "./model/typescript/duplicate-cat";
 import { IDuplicateCat } from "./model/json/i-duplicate-cat";
 import { IOptionalCat } from './model/json/i-optional-cat';
 import { OptionalCat } from './model/typescript/optional-cat';
+import { IAnimal } from './model/json/i-animal';
 
 describe('Integration tests', () => {
 
@@ -62,6 +63,25 @@ describe('Integration tests', () => {
         let animalJsonArray = [cat1JsonObject, dog1JsonObject];
         let catsJsonArray = [cat1JsonObject, cat2JsonObject];
 
+        // JSON objects with only Animal base properties
+        let cat1AnimalOnlyJson: IAnimal = {
+            name: "Meowy",
+            owner: human1JsonObject,
+            birthdate: "2016-01-02",
+            friends: []
+        };
+        let cat2AnimalOnlyJson: IAnimal = {
+            name: "Links",
+            birthdate: "2016-01-02"
+        };
+        let dog1AnimalOnlyJson: IAnimal = {
+            name: "Barky",
+            birthdate: "2016-01-02",
+            friends: []
+        };
+        let animalsOnlyJsonArray = [cat1AnimalOnlyJson, dog1AnimalOnlyJson];
+        let catsAnimalOnlyJsonArray = [cat1AnimalOnlyJson, cat2AnimalOnlyJson];
+
         // TYPESCRIPT INSTANCES
         let human1 = new Human();
         human1.firstname = "Andreas";
@@ -101,6 +121,35 @@ describe('Integration tests', () => {
         let animals = [cat1, dog1];
         let cats = [cat1, cat2];
 
+        // JSON objects using Typescript mappings
+        let cat1Typescript: any = {
+            name: "Meowy",
+            district: 100,
+            owner: {
+                firstname: "Andreas",
+                lastname: "Muster"
+            },
+            birthdate: new Date("2016-01-02"),
+            friends: [],
+            talky: false,
+            other: ""
+        };
+        let cat2Typescript: any = {
+            name: "Links",
+            district: 50,
+            birthdate: new Date( "2016-01-02" ),
+            talky: true,
+            other: ""
+        };
+        let dogTypescript: any = {
+            name: "Barky",
+            isBarking: true,
+            birthdate: new Date("2016-01-02"),
+            friends: [],
+            other: 0
+        };
+        let animalsTypescript = [cat1Typescript, dogTypescript];
+        let catsTypescript = [cat1Typescript, cat2Typescript];
 
         // SERIALIZE INTEGRATION
         describe('serialize', () => {
@@ -129,6 +178,29 @@ describe('Integration tests', () => {
                 expect(jsonConvert.serializeArray<Cat>(cats)).toEqual(catsJsonArray);
 
                 expect(() => jsonConvert.serializeArray<Cat>(<any> cat1)).toThrow();
+            });
+
+            it('should serialize a plain object using Typescript class mappings', () => {
+                expect(jsonConvert.serialize(cat1Typescript, Cat)).toEqual(cat1JsonObject);
+                expect(jsonConvert.serialize(dogTypescript, Dog)).toEqual(dog1JsonObject);
+                expect(jsonConvert.serializeObject(cat1Typescript, Cat)).toEqual(cat1JsonObject);
+                expect(jsonConvert.serializeObject(dogTypescript, Dog)).toEqual(dog1JsonObject);
+
+                expect(() => jsonConvert.serializeObject(catsTypescript, Cat)).toThrow();
+            });
+
+            it('should serialize a plain array using Typescript class mappings', () => {
+                expect(jsonConvert.serialize(catsTypescript, Animal)).toEqual(catsAnimalOnlyJsonArray);
+                expect(jsonConvert.serialize(catsTypescript, Cat)).toEqual(catsJsonArray);
+                expect(jsonConvert.serialize(animalsTypescript, Animal)).toEqual(animalsOnlyJsonArray);
+                expect(jsonConvert.serializeArray(catsTypescript, Animal)).toEqual(catsAnimalOnlyJsonArray);
+                expect(jsonConvert.serializeArray(catsTypescript, Cat)).toEqual(catsJsonArray);
+                expect(jsonConvert.serializeArray(animalsTypescript, Animal)).toEqual(animalsOnlyJsonArray);
+
+                expect(() => jsonConvert.serializeArray(cat1Typescript, Cat)).toThrow();
+                // Should throw an error if attempting to serialize an array containing a Dog using Cat mappings
+                // because required properties are missing
+                expect(() => jsonConvert.serializeArray(animalsTypescript, Cat)).toThrow();
             });
 
             it('should throw an error if serializing a Typescript object with a missing property', () => {

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -185,20 +185,20 @@ describe('Unit tests', () => {
                 } );
 
                 it('should serialize property with different class and JSON names', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "name", t_cat);
                     expect((<any>t_cat)["catName"]).toBe(cat1.name);
                 });
                 it('should serialize property with no declared property name', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "district", t_cat);
                     expect((<any>t_cat)["district"]).toBe(100);
                 });
                 it('should serialize a child object property', () => {
-                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, cat1, "owner", t_cat);
                     expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
                 });
                 it('should throw an error if required property is missing', () => {
                     expect( function () {
-                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat )
+                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, optionalCat1, 'district', t_cat )
                     } ).toThrowError( 'Fatal error in JsonConvert. ' +
                         'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
                         '"district" does not exist or is not defined:\n\n' +
@@ -207,7 +207,7 @@ describe('Unit tests', () => {
                 });
                 it('should not throw an error if required property is missing but ignoreRequiredCheck flag set', () => {
                     jsonConvert.ignoreRequiredCheck = true;
-                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat );
+                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, optionalCat1, 'district', t_cat );
                     expect( ( <any>t_cat )[ 'district' ] ).toBeUndefined( 'No value set, but no error thrown' );
                     jsonConvert.ignoreRequiredCheck = false;
                 });
@@ -266,7 +266,7 @@ describe('Unit tests', () => {
 
             it('serializeObject_loopProperty()', () => {
                 let t_cat = {};
-                (<any>jsonConvert).serializeObject_loopProperty(cat2, "owner", t_cat);
+                (<any>jsonConvert).serializeObject_loopProperty(cat2, cat2, "owner", t_cat);
                 expect((<any>t_cat)["owner"]).toBe(undefined);
             });
             it('deserializeObject_loopProperty()', () => {

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -10,6 +10,7 @@ import { ICat } from "./model/json/i-cat";
 import { IDog } from "./model/json/i-dog";
 import { DuplicateCat } from "./model/typescript/duplicate-cat";
 import { DateConverter } from "./model/typescript/date-converter";
+import { OptionalCat } from './model/typescript/optional-cat';
 
 describe('Unit tests', () => {
 
@@ -84,6 +85,10 @@ describe('Unit tests', () => {
         duplicateCat1.district = new Date("2014-10-01");
         duplicateCat1.talky = new Date("2015-02-03");
 
+        // TYPESCRIPT OPTIONAL INSTANCES
+        let optionalCat1 = new OptionalCat();
+        optionalCat1.name = "MaybeMeowy";
+
         // SETUP CHECKS
         describe('setup checks', () => {
             it('JsonConvert instance', () => {
@@ -94,21 +99,25 @@ describe('Unit tests', () => {
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert(OperationMode.DISABLE, ValueCheckingMode.ALLOW_NULL, true);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.DISABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(true);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert(OperationMode.LOGGING, ValueCheckingMode.DISALLOW_NULL, false);
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.LOGGING);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.DISALLOW_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
                 jsonConvertTest = new JsonConvert();
                 expect(jsonConvertTest.operationMode).toEqual(OperationMode.ENABLE);
                 expect(jsonConvertTest.valueCheckingMode).toEqual(ValueCheckingMode.ALLOW_OBJECT_NULL);
                 expect(jsonConvertTest.ignorePrimitiveChecks).toEqual(false);
+                expect(jsonConvertTest.ignoreRequiredCheck).toEqual(false);
 
             });
 
@@ -169,43 +178,88 @@ describe('Unit tests', () => {
 
             jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
 
-            it('serializeObject_loopProperty()', () => {
-                let t_cat = {};
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
-                expect((<any>t_cat)["catName"]).toBe(cat1.name);
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
-                expect((<any>t_cat)["district"]).toBe(100);
-                (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
-                expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
-            });
-            it('deserializeObject_loopProperty()', () => {
-                let t_cat = new Cat();
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catName": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "district", {"district": 100});
-                expect(t_cat.district).toEqual(100);
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "owner", {
-                    "owner": {
-                        givenName: "Andreas",
-                        lastName: "Muster"
-                    }
+            describe('serializeObject_loopProperty()', () => {
+                let t_cat: any;
+                beforeEach( () => {
+                    t_cat = {};
+                } );
+
+                it('should serialize property with different class and JSON names', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "name", t_cat);
+                    expect((<any>t_cat)["catName"]).toBe(cat1.name);
                 });
-                expect(t_cat.owner!.lastname).toEqual("Muster");
+                it('should serialize property with no declared property name', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "district", t_cat);
+                    expect((<any>t_cat)["district"]).toBe(100);
+                });
+                it('should serialize a child object property', () => {
+                    (<any>jsonConvert).serializeObject_loopProperty(cat1, "owner", t_cat);
+                    expect((<any>t_cat)["owner"]["givenName"]).toBe("Andreas");
+                });
+                it('should throw an error if required property is missing', () => {
+                    expect( function () {
+                        ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat )
+                    } ).toThrowError( 'Fatal error in JsonConvert. ' +
+                        'Failed to map the JavaScript instance of class "OptionalKitty" to JSON because the defined class property ' +
+                        '"district" does not exist or is not defined:\n\n' +
+                        '\tClass property: \n\t\tdistrict\n\n' +
+                        '\tJSON property: \n\t\tdistrictNumber\n\n' );
+                });
+                it('should not throw an error if required property is missing but ignoreRequiredCheck flag set', () => {
+                    jsonConvert.ignoreRequiredCheck = true;
+                    ( <any>jsonConvert ).serializeObject_loopProperty( optionalCat1, 'district', t_cat );
+                    expect( ( <any>t_cat )[ 'district' ] ).toBeUndefined( 'No value set, but no error thrown' );
+                    jsonConvert.ignoreRequiredCheck = false;
+                });
+            });
+            describe('deserializeObject_loopProperty()', () => {
+                let t_cat: Cat;
+                beforeEach( () => {
+                    t_cat = new Cat();
+                } );
 
-                let t_dog = new Dog();
-                (<any>jsonConvert).deserializeObject_loopProperty(t_dog, "name", {"name": "Barky"});
-                expect(t_dog.name).toEqual("Barky");
+                it( 'should deserialize properties', () => {
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catName': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'district', { 'district': 100 } );
+                    expect( t_cat.district ).toEqual( 100 );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'owner', {
+                        'owner': {
+                            givenName: 'Andreas',
+                            lastName: 'Muster'
+                        }
+                    } );
+                    expect( t_cat.owner!.lastname ).toEqual( 'Muster' );
 
-                jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_INSENSITIVE;
+                    let t_dog = new Dog();
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_dog, 'name', { 'name': 'Barky' } );
+                    expect( t_dog.name ).toEqual( 'Barky' );
 
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catName": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catNAME": "Meowy"});
-                expect(t_cat.name).toEqual("Meowy");
-                expect(() => (<any>jsonConvert).deserializeObject_loopProperty(t_cat, "name", {"catNames": "Meowy"})).toThrow();
+                    jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_INSENSITIVE;
 
-                jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_STRICT;
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catName': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catNAME': 'Meowy' } );
+                    expect( t_cat.name ).toEqual( 'Meowy' );
+                    expect( () => ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', { 'catNames': 'Meowy' } ) ).toThrow();
 
+                    jsonConvert.propertyMatchingRule = PropertyMatchingRule.CASE_STRICT;
+                } );
+                it( 'should throw an error if required property is missing', () => {
+                    expect( function () {
+                        ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', {} );
+                    } ).toThrowError( 'Fatal error in JsonConvert. ' +
+                      'Failed to map the JSON object to the class "Kitty" because the defined JSON property "catName" does not exist:\n\n' +
+                      '\tClass property: \n\t\tname\n\n' +
+                      '\tJSON property: \n\t\tcatName\n\n'
+                    );
+                } );
+                it( 'should not throw an error if required property is missing but ignoreRequiredCheck flag is set', () => {
+                    jsonConvert.ignoreRequiredCheck = true;
+                    ( <any>jsonConvert ).deserializeObject_loopProperty( t_cat, 'name', {} );
+                    expect( t_cat.name ).toEqual( '', 'Value not set because not present, default value used' );
+                    jsonConvert.ignoreRequiredCheck = false;
+                } );
             });
 
             jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;

--- a/test/model/json/i-optional-cat.ts
+++ b/test/model/json/i-optional-cat.ts
@@ -1,0 +1,7 @@
+export interface IOptionalCat {
+    catName: string;
+    owner?: object | null;
+    birthdate?: string | null;
+    friends?: any[] | null;
+    district?: number;
+}

--- a/test/model/typescript/optional-cat.ts
+++ b/test/model/typescript/optional-cat.ts
@@ -1,0 +1,14 @@
+import { JsonObject, JsonProperty } from "../../../src/json2typescript/json-convert-decorators";
+
+import { Animal } from "./animal";
+
+@JsonObject("OptionalKitty")
+export class OptionalCat extends Animal {
+
+    @JsonProperty("catName", String)
+    name: string = "";
+
+    @JsonProperty("districtNumber", Number)
+    district?: number = undefined;
+
+}


### PR DESCRIPTION
Reopening a pull request similar to #92 using a rebased branch.

This includes 2 new features:
1. New ignoreRequiredCheck flag which effectively makes all properties optional, even if the property mapping doesn't specify isOptional = true. (commit 85747a84d68d30dc19cd8d4d0f893881d81e2d75)
2. Added optional classReference parameters to all serialization methods, to allow serialization of an object using mappings from the specified class reference instead of mappings from the object itself. (commit 0a044c2a289484d4f0f55a06d3e30f3000af211e)

These are both features needed to support my specific use case.  My data is represented by a nested structure of typescript classes with JSON mapping annotations.  This data is filled in using Angular forms, which output a mix of pure JSON objects and typescript class objects, depending on the control values - I want to be able to send this data to the back end directly using my pre-defined mapping annotations.  Additionally, because the data structure is large, users need to be able to edit portions of the data, and I want to serialize these patch objects without triggering an error due to other required properties not being present.

So these new features for me solve 2 problems:

1. By serializing an object using mappings defined on another class, I can easily serialize my form output to send to the back end without having to do a lot of additional logic or data management.
2. By skipping the required property check, I can serialize partial (patch) objects that match my defined class without errors, but still enforce the requirements when deserializing.

As a trivial example, say I have the classes:
```
// Dictionary class, not editable by user
@JsonObject("Country")
export class Country {
    @JsonProperty("countryName", String)
    name: string = undefined;
}

@JsonObject("Parent")
export class Person {
    @JsonProperty("name", String)
    name: string = undefined;
    @JsonProperty("country", Country)
    country: Country = undefined;
}
```
Together, these features let me serialize a patch edit object of the parent where I change the country without affecting the name property, and let me use the mappings defined on my classes to do so:
```
const formOutput = {
    country: {
        name: "Some Country"
    }
};
// No errors will be thrown, and the output JSON will have the country.name property
// mapped as country.countryName.
const json = jsonConvert.serializeObject(formOutput, Person);
```
