### PR TITLE
Typed JsonObject

### DIFF
--- a/src/json2typescript/json-convert-decorators.ts
+++ b/src/json2typescript/json-convert-decorators.ts
@@ -19,7 +19,7 @@ export function JsonConverter(target: any): void {
  *
  * @throws Error
  */
-export function JsonObject(target: string | any): any {
+export function JsonObject(target: string | any): (target: any) => void {
     // target is the constructor or the custom class name
 
     let classIdentifier = "";


### PR DESCRIPTION
The `@JsonObject` annotation does not currently comply with TSLint [no-unsafe-any rule](https://palantir.github.io/tslint/rules/no-unsafe-any/). This typing fixes this.