### PR TITLE
Fix handling of array property type mapping

### DIFF
--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -869,75 +869,68 @@ export class JsonConvert {
 
         }
 
-        // Check if attempt and expected was n-d
-        if (expectedJsonType instanceof Array && value instanceof Array) {
-
-            let array: any[] = [];
-
-            // No data given, so return empty value
-            if (value.length === 0) {
-                return array;
-            }
-
-            // We obviously don't care about the type, so return the value as is
-            if (expectedJsonType.length === 0) {
-                return value;
-            }
-            // Copy the expectedJsonType array so we don't change the class-level mapping based on the value of this property
-            const jsonType: any[] = expectedJsonType.slice(0);
-
-            // Loop through the data. Both type and value are at least of length 1
-            let autofillType: boolean = jsonType.length < value.length;
-            for (let i = 0; i < value.length; i++) {
-
-                if (autofillType && i >= jsonType.length) jsonType[i] = jsonType[i - 1];
-
-                array[i] = this.verifyProperty(jsonType[i], value[i], serialize);
-
-            }
-
-            return array;
-
-        }
-
-        // Check if attempt was 1-d and expected was n-d
-        if (expectedJsonType instanceof Array && value instanceof Object) {
-
-            let array: any[] = [];
-
-            // No data given, so return empty value
-            if (value.length === 0) {
-                return array;
-            }
-
-            // We obviously don't care about the type, so return the json value as is
-            if (expectedJsonType.length === 0) {
-                return value;
-            }
-
-            // Loop through the data. Both type and value are at least of length 1
-            let autofillType: boolean = expectedJsonType.length < Object.keys(value).length;
-            let i = 0;
-            for (let key in value) {
-
-                if (autofillType && i >= expectedJsonType.length) expectedJsonType[i] = expectedJsonType[i - 1];
-
-                array[key as any] = this.verifyProperty(expectedJsonType[i], value[key]);
-
-                i++;
-            }
-
-            return array;
-
-        }
-
-        // Check if attempt was 1-d and expected was n-d
+        // Check if expected was n-d
         if (expectedJsonType instanceof Array) {
             if (value === null) {
                 if (this.valueCheckingMode !== ValueCheckingMode.DISALLOW_NULL) return null;
                 else throw new Error("\tReason: Given value is null.");
             }
-            throw new Error("\tReason: Expected type is array, but given value is non-array.");
+
+            // Check that value is not primitive
+            if (value instanceof Object) {
+                let array: any[] = [];
+
+                // No data given, so return empty value
+                if (value.length === 0) {
+                    return array;
+                }
+
+                // We obviously don't care about the type, so return the value as is
+                if (expectedJsonType.length === 0) {
+                    return value;
+                }
+                // Copy the expectedJsonType array so we don't change the class-level mapping based on the value of this property
+                const jsonType: any[] = expectedJsonType.slice(0);
+
+                // Check if attempt was n-d
+                if (value instanceof Array) {
+
+                    // Loop through the data. Both type and value are at least of length 1
+                    let autofillType: boolean = jsonType.length < value.length;
+                    for (let i = 0; i < value.length; i++) {
+
+                        if (autofillType && i >= jsonType.length) {
+                            jsonType[i] = jsonType[i - 1];
+                        }
+
+                        array[i] = this.verifyProperty(jsonType[i], value[i], serialize);
+
+                    }
+
+                    return array;
+
+                // Otherwise attempt was 1-d
+                } else {
+
+                    // Loop through the data. Both type and value are at least of length 1
+                    let autofillType: boolean = jsonType.length < Object.keys(value).length;
+                    let i = 0;
+                    for (let key in value) {
+
+                        if (autofillType && i >= jsonType.length) {
+                            jsonType[i] = jsonType[i - 1];
+                        }
+
+                        array[key as any] = this.verifyProperty(jsonType[i], value[key]);
+
+                        i++;
+                    }
+
+                    return array;
+                }
+            } else {
+                throw new Error("\tReason: Expected type is array, but given value is primitive.");
+            }
         }
 
         // Check if attempt was n-d and expected as 1-d

--- a/src/json2typescript/json-convert.ts
+++ b/src/json2typescript/json-convert.ts
@@ -883,14 +883,16 @@ export class JsonConvert {
             if (expectedJsonType.length === 0) {
                 return value;
             }
+            // Copy the expectedJsonType array so we don't change the class-level mapping based on the value of this property
+            const jsonType: any[] = expectedJsonType.slice(0);
 
             // Loop through the data. Both type and value are at least of length 1
-            let autofillType: boolean = expectedJsonType.length < value.length;
+            let autofillType: boolean = jsonType.length < value.length;
             for (let i = 0; i < value.length; i++) {
 
-                if (autofillType && i >= expectedJsonType.length) expectedJsonType[i] = expectedJsonType[i - 1];
+                if (autofillType && i >= jsonType.length) jsonType[i] = jsonType[i - 1];
 
-                array[i] = this.verifyProperty(expectedJsonType[i], value[i], serialize);
+                array[i] = this.verifyProperty(jsonType[i], value[i], serialize);
 
             }
 

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -28,7 +28,7 @@ describe('Integration tests', () => {
             catName: "Meowy",
             district: 100,
             owner: human1JsonObject,
-            birthdate: "2016-01-02",
+            birthdate: "2016-01-01",
             friends: [],
             talky: false,
             other: ""
@@ -36,7 +36,7 @@ describe('Integration tests', () => {
         let dog1JsonObject: IDog = {
             name: "Barky",
             barking: true,
-            birthdate: "2016-01-02",
+            birthdate: "2017-02-12",
             friends: [],
             other: 0,
             toys: ["pizza", "bone", "ball"]
@@ -44,7 +44,7 @@ describe('Integration tests', () => {
         let cat2JsonObject: ICat = {
             catName: "Links",
             district: 50,
-            birthdate: "2016-01-02",
+            birthdate: "2016-05-19",
             talky: true,
             other: ""
         };
@@ -68,16 +68,16 @@ describe('Integration tests', () => {
         let cat1AnimalOnlyJson: IAnimal = {
             name: "Meowy",
             owner: human1JsonObject,
-            birthdate: "2016-01-02",
+            birthdate: "2016-01-01",
             friends: []
         };
         let cat2AnimalOnlyJson: IAnimal = {
             name: "Links",
-            birthdate: "2016-01-02"
+            birthdate: "2016-05-19"
         };
         let dog1AnimalOnlyJson: IAnimal = {
             name: "Barky",
-            birthdate: "2016-01-02",
+            birthdate: "2017-02-12",
             friends: []
         };
         let animalsOnlyJsonArray = [cat1AnimalOnlyJson, dog1AnimalOnlyJson];
@@ -92,20 +92,20 @@ describe('Integration tests', () => {
         cat1.name = "Meowy";
         cat1.district = 100;
         cat1.owner = human1;
-        cat1.birthdate = new Date("2016-01-02");
+        cat1.birthdate = new Date("2016-01-01");
         cat1.friends = [];
 
         let dog1 = new Dog();
         dog1.name = "Barky";
         dog1.isBarking = true;
-        dog1.birthdate = new Date("2016-01-02");
+        dog1.birthdate = new Date("2017-02-12");
         dog1.friends = [];
         dog1.toys = ["pizza", "bone", "ball"];
 
         let cat2 = new Cat();
         cat2.name = "Links";
         cat2.district = 50;
-        cat2.birthdate = new Date("2016-01-02");
+        cat2.birthdate = new Date("2016-05-19");
         cat2.talky = true;
 
         let duplicateCat1 = new DuplicateCat();
@@ -131,7 +131,7 @@ describe('Integration tests', () => {
                 firstname: "Andreas",
                 lastname: "Muster"
             },
-            birthdate: new Date("2016-01-02"),
+            birthdate: new Date("2016-01-01"),
             friends: [],
             talky: false,
             other: ""
@@ -139,14 +139,14 @@ describe('Integration tests', () => {
         let cat2Typescript: any = {
             name: "Links",
             district: 50,
-            birthdate: new Date( "2016-01-02" ),
+            birthdate: new Date( "2016-05-19" ),
             talky: true,
             other: ""
         };
         let dogTypescript: any = {
             name: "Barky",
             isBarking: true,
-            birthdate: new Date("2016-01-02"),
+            birthdate: new Date("2017-02-12"),
             friends: [],
             other: 0,
             toys: ["pizza", "bone", "ball"]

--- a/test/json2typescript.integration.ts
+++ b/test/json2typescript.integration.ts
@@ -38,7 +38,8 @@ describe('Integration tests', () => {
             barking: true,
             birthdate: "2016-01-02",
             friends: [],
-            other: 0
+            other: 0,
+            toys: ["pizza", "bone", "ball"]
         };
         let cat2JsonObject: ICat = {
             catName: "Links",
@@ -99,6 +100,7 @@ describe('Integration tests', () => {
         dog1.isBarking = true;
         dog1.birthdate = new Date("2016-01-02");
         dog1.friends = [];
+        dog1.toys = ["pizza", "bone", "ball"];
 
         let cat2 = new Cat();
         cat2.name = "Links";
@@ -146,7 +148,8 @@ describe('Integration tests', () => {
             isBarking: true,
             birthdate: new Date("2016-01-02"),
             friends: [],
-            other: 0
+            other: 0,
+            toys: ["pizza", "bone", "ball"]
         };
         let animalsTypescript = [cat1Typescript, dogTypescript];
         let catsTypescript = [cat1Typescript, cat2Typescript];
@@ -225,6 +228,16 @@ describe('Integration tests', () => {
                 jsonConvert.ignoreRequiredCheck = false;
             });
 
+            it('should not mutate the expected JSON type mapping for array properties', () => {
+                const dog2 = new Dog();
+                dog2.toys = ["stick", "ball", "bone"];
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog2, "toys").expectedJsonType)
+                  .toEqual([String], "initial expectedJsonType before serializing");
+                jsonConvert.serialize(dog2);
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog2, "toys").expectedJsonType)
+                  .toEqual([String], "expectedJsonType after serializing");
+            });
+
         });
 
         // DESERIALIZE INTEGRATION
@@ -274,6 +287,15 @@ describe('Integration tests', () => {
                 expect(jsonConvert.deserialize(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
                 expect(jsonConvert.deserializeObject(optionalCatJsonObject, OptionalCat)).toEqual(optionalCat);
                 jsonConvert.ignoreRequiredCheck = false;
+            });
+
+            it('should not mutate the expected JSON type mapping for array properties', () => {
+                const dog2 = new Dog();
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog2, "toys").expectedJsonType)
+                  .toEqual([String], "initial expectedJsonType before deserializing");
+                jsonConvert.deserialize(dog1JsonObject, Dog);
+                expect((<any>jsonConvert).getClassPropertyMappingOptions(dog2, "toys").expectedJsonType)
+                  .toEqual([String], "expectedJsonType after deserializing");
             });
 
         });

--- a/test/json2typescript.unit.ts
+++ b/test/json2typescript.unit.ts
@@ -40,8 +40,7 @@ describe('Unit tests', () => {
             district: 50,
             talky: true,
             other: "sweet",
-            birthdate: "2014-09-01",
-            friends: null
+            birthdate: "2014-09-01"
         };
         let dog1JsonObject: IDog = {
             name: "Barky",
@@ -317,10 +316,150 @@ describe('Unit tests', () => {
                 // Unmapped property should not return mapping, even though property is the same name as a mapped property on another class
                 expect((<any>jsonConvert).getClassPropertyMappingOptions(duplicateCat1, "district")).toBeNull();
             });
-            it('verifyProperty()', () => {
-                expect((<any>jsonConvert).verifyProperty(String, "Andreas", false)).toBe("Andreas");
-                expect((<any>jsonConvert).verifyProperty([String, [Boolean, Number]], ["Andreas", [true, 2.2]], false)).toEqual(["Andreas", [true, 2.2]]);
-                expect(() => (<any>jsonConvert).verifyProperty(Number, "Andreas", false)).toThrow();
+            describe("verifyProperty()", () => {
+                let jsonConvert: JsonConvert;
+                beforeEach(() => {
+                    jsonConvert = new JsonConvert();
+                    jsonConvert.ignorePrimitiveChecks = false;
+                    jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
+                });
+                describe("expectedJsonType unmapped", () => {
+                    it("should return the value if expected type is Any, Object, or null", () => {
+                        expect((<any>jsonConvert).verifyProperty(Any, cat1, true)).toBe(cat1);
+                        expect((<any>jsonConvert).verifyProperty(Object, cat1, false)).toBe(cat1);
+                        expect((<any>jsonConvert).verifyProperty(null, cat1, true)).toBe(cat1);
+                    });
+                    it("should NOT throw an error even if null not allowed", () => {
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;
+                        expect((<any>jsonConvert).verifyProperty(Any, null, true)).toBeNull("expected Any");
+                        expect((<any>jsonConvert).verifyProperty(Object, null, false)).toBeNull("expected Object");
+                        expect((<any>jsonConvert).verifyProperty(null, null, true)).toBeNull("expected null");
+                    });
+                });
+                describe("expectedJsonType mapped class", () => {
+                    it("should correctly serialize/deserialize a mapped object property", () => {
+                        expect((<any>jsonConvert).verifyProperty(Cat, cat2, true)).toEqual(cat2JsonObject);
+                        expect((<any>jsonConvert).verifyProperty(Cat, cat1JsonObject, false)).toEqual(cat1);
+                    });
+                    it("should return null if allowed", () => {
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_OBJECT_NULL;
+                        expect((<any>jsonConvert).verifyProperty(Cat, null, true))
+                            .toBeNull("serializing null returns null");
+                        expect((<any>jsonConvert).verifyProperty(Cat, null, false))
+                            .toBeNull("deserializing null returns null");
+                    });
+                    it("should throw an error if null not allowed", () => {
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;
+                        const errorMessage = "\tReason: Given value is null.";
+                        expect(() => (<any>jsonConvert).verifyProperty(Cat, null, true))
+                            .toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty(Cat, null, false))
+                            .toThrowError(errorMessage);
+                    });
+                    it("should throw an error if value is an array", () => {
+                        expect(() => (<any>jsonConvert).verifyProperty(Cat, [cat1, cat2], true))
+                            .toThrowError("\tReason: Given value is array, but expected a non-array type.");
+                    });
+                });
+                describe("expectedJsonType primitive", () => {
+                    it("should correctly serialize and deserialize expected primitive values", () => {
+                        expect((<any>jsonConvert).verifyProperty(String, "Andreas", false)).toBe("Andreas");
+                        expect((<any>jsonConvert).verifyProperty(Number, 2.2, false)).toBe(2.2);
+                        expect((<any>jsonConvert).verifyProperty(Boolean, true, true)).toBe(true);
+                    });
+                    it("should error if expected JSON type doesn't match value type", () => {
+                        const errorMessage = "\tReason: Given object does not match the expected primitive type.";
+                        expect(() => (<any>jsonConvert).verifyProperty(Number, "Andreas", false)).toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty(String, true, true)).toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty(Boolean, 54, true)).toThrowError(errorMessage);
+                    });
+                    it("should return value if expected JSON type doesn't match value type but flag set", () => {
+                        jsonConvert.ignorePrimitiveChecks = true;
+                        expect((<any>jsonConvert).verifyProperty(Number, "Andreas", false)).toBe("Andreas");
+                        expect((<any>jsonConvert).verifyProperty(String, true, true)).toBe(true);
+                        expect((<any>jsonConvert).verifyProperty(Boolean, 54, true)).toBe(54);
+                    });
+                    it("should return null if nulls allowed", () => {
+                        expect((<any>jsonConvert).verifyProperty(String, null, false)).toBeNull("expected string should be null");
+                        expect((<any>jsonConvert).verifyProperty(Number, null, false)).toBeNull("expected number should be null");
+                        expect((<any>jsonConvert).verifyProperty(Boolean, null, true)).toBeNull("expected boolean should be null");
+                    });
+                    it("should throw an error if only object nulls allowed", () => {
+                        const errorMessage = "\tReason: Given value is null.";
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_OBJECT_NULL;
+                        expect(() => (<any>jsonConvert).verifyProperty(String, null, false))
+                            .toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty(Number, null, false))
+                            .toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty(Boolean, null, true))
+                            .toThrowError(errorMessage);
+                    });
+                    it("should throw an error if value is an array", () => {
+                        expect(() => (<any>jsonConvert).verifyProperty(String, ["Andreas", "Joseph"], true))
+                            .toThrowError("\tReason: Given value is array, but expected a non-array type.");
+                    });
+                });
+                describe("expectedJsonType array", () => {
+                    it("should return value as-is if expected type is empty", () => {
+                        const pseudoArray = {
+                            "0": "Andreas",
+                            "1": {"0": true, "1": 2.2}
+                        };
+                        expect((<any>jsonConvert).verifyProperty([], pseudoArray, true)).toBe(pseudoArray);
+                        expect((<any>jsonConvert).verifyProperty([], cat1, false)).toBe(cat1);
+                    });
+                    it("should return empty array if value is empty", () => {
+                        expect((<any>jsonConvert).verifyProperty([String], [], true)).toEqual([]);
+                        expect((<any>jsonConvert).verifyProperty([String, [Boolean, Number]], [], false)).toEqual([]);
+                        expect((<any>jsonConvert).verifyProperty([Cat], [], false)).toEqual([]);
+                    });
+                    it("should correctly handle array of object types", () => {
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.ALLOW_NULL;
+                        expect((<any>jsonConvert).verifyProperty([Cat], [cat1, cat2], true))
+                            .toEqual([cat1JsonObject, cat2JsonObject]);
+                        expect((<any>jsonConvert).verifyProperty([Cat], [cat1JsonObject, cat2JsonObject], false))
+                            .toEqual([cat1, cat2]);
+                    });
+                    it("should correctly handle expected nested array types", () => {
+                        expect((<any>jsonConvert).verifyProperty([String, [Boolean, Number]], ["Andreas", [true, 2.2]], false))
+                            .toEqual(["Andreas", [true, 2.2]]);
+                        expect((<any>jsonConvert).verifyProperty([String, [Boolean, Number]], {
+                            "0": "Andreas",
+                            "1": {"0": true, "1": 2.2}
+                        }, true)).toEqual(["Andreas", [true, 2.2]]);
+                    });
+                    it("should expand expected array type as needed without affecting original mapping", () => {
+                        const expectedJsonType = [String];
+                        expect((<any>jsonConvert).verifyProperty(expectedJsonType, ["Andreas", "Joseph", "Albert"], true))
+                            .toEqual(["Andreas", "Joseph", "Albert"]);
+                        expect(expectedJsonType).toEqual([String]);
+
+                        expect((<any>jsonConvert).verifyProperty(expectedJsonType, {"0": "Andreas", "1": "Joseph", "2": "Albert"}))
+                            .toEqual(["Andreas", "Joseph", "Albert"]);
+                        expect(expectedJsonType).toEqual([String]);
+                    });
+                    it("should throw an error if expected array and value is primitive", () => {
+                        const errorMessage = "\tReason: Expected type is array, but given value is primitive."
+                        expect(() => (<any>jsonConvert).verifyProperty([String], "Andreas"))
+                            .toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty([], "Andreas"))
+                            .toThrowError(errorMessage);
+                    });
+                    it("should return null if nulls allowed", () => {
+                        expect((<any>jsonConvert).verifyProperty([String], null, true))
+                            .toBeNull("expected string array should be null");
+                        expect((<any>jsonConvert).verifyProperty([String, [Boolean, Number]], null, true))
+                            .toBeNull("expected nested array should be null");
+                    });
+                    it("should throw an error if nulls disallowed", () => {
+                        const errorMessage = "\tReason: Given value is null.";
+                        jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL;
+                        expect(() => (<any>jsonConvert).verifyProperty([String], null, true))
+                            .toThrowError(errorMessage);
+                        expect(() => (<any>jsonConvert).verifyProperty([String, [Boolean, Number]], null, true))
+                            .toThrowError(errorMessage);
+                    });
+                });
             });
             it('getObjectValue()', () => {
                 expect((<any>jsonConvert).getObjectValue({ "name": "Andreas" }, "name")).toBe("Andreas");

--- a/test/model/json/i-dog.ts
+++ b/test/model/json/i-dog.ts
@@ -5,4 +5,5 @@ export interface IDog {
     friends?: any[];
     barking: boolean;
     other: number;
+    toys?: string[];
 }

--- a/test/model/typescript/date-converter.ts
+++ b/test/model/typescript/date-converter.ts
@@ -5,10 +5,10 @@ import { JsonCustomConvert } from "../../../src/json2typescript/json-custom-conv
 export class DateConverter implements JsonCustomConvert<Date | null> {
     serialize(date: Date | null): any {
         if (date instanceof Date) {
-            let year = date.getFullYear();
-            let month = date.getMonth() + 1;
-            let day = date.getUTCDate();
-            return year + "-" + (month < 10 ? "0" + month : month) + "-" + (day < 10 ? "0" + day : day);
+            // Convert to standard ISO format, which is in UTC
+            const isoString = date.toISOString();
+            // Split on the "T" separator and return just the date portion
+            return isoString.split("T")[0];
         } else {
             return null;
         }

--- a/test/model/typescript/dog.ts
+++ b/test/model/typescript/dog.ts
@@ -11,4 +11,6 @@ export class Dog extends Animal {
     @JsonProperty("other", Number)
     other: number = 0;
 
+    @JsonProperty("toys", [String], true)
+    toys?: string[] = undefined;
 }


### PR DESCRIPTION
Currently, in the JsonConvert.verifyProperty() method, if the expected JSON type of the property is an array, the mapping property holding the expected JSON type is mutated based on the values of that object.  However, because the mapping property is attached to the Object prototype, this means ALL objects of that class now have the modified expected JSON type.

Instead, the verifyProperty() method should create a local copy of the exected JSON type array and mutate that, rather than mutating the class-level property.

Note that this change is also necessary if you use ngrx, which makes all properties immutable (including inherited and class-level ones) - without it, you can't serialize/deserialize objects that have been added to the store.