### PR TITLE
Fix to resolve CommonJS issue with angular 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /coverage
 /node_modules
 /dist
+/lib
 *.tgz
 *.d.ts
 *.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json2typescript",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3340,9 +3340,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://appvision.ch",
   "scripts": {
     "test": "karma start karma.conf.js",
-    "build": "npm i && npm run test && tsc && npx downlevel-dts . ts3.4 && cp -r ts3.4/* . && rm -r ts3.4",
+    "build": "npm i && npm run test && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && npx downlevel-dts . ts3.4 && cp -r ts3.4/* . && rm -r ts3.4",
     "dist": "npm run build && npm pack"
   },
   "typescript": {
@@ -39,16 +39,12 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-typescript": "^5.0.2",
     "phantomjs-prebuilt": "^2.1.16",
-    "typescript": "3.8.3"
+    "typescript": "3.9.5"
   },
-  "main": "index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
   "files": [
-    "src/json2typescript/*.d.ts",
-    "src/json2typescript/*.map",
-    "src/json2typescript/*.js",
-    "index.d.ts",
-    "index.js.map",
-    "index.js"
+    "lib/"
   ],
   "repository": {
     "type": "git",

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "CommonJS",
+        "outDir": "./lib/cjs"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,13 @@
       "es6",
       "dom"
     ],
-    "module": "commonjs",
+    "module": "esnext",
     "removeComments": false,
     "target": "es5",
     "sourceMap": true,
     "strictNullChecks": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "outDir": "./lib/esm"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Fix to resolve Angular 10 warning;

```
WARNING in \src\webapp\src\app\services\app-globals.service.ts depends on json2typescript. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```

I made modifications needed to pack simultaneously both versions, the new one using esm module format (compatible angular 10) and the old commonjs module format fo those who need compatibility with old js versions.


I also update TS to last version.
